### PR TITLE
Prevent Codex probes from freezing startup

### DIFF
--- a/change-logs/2026/09/12/fix-codex-startup-probe-timeouts.md
+++ b/change-logs/2026/09/12/fix-codex-startup-probe-timeouts.md
@@ -1,0 +1,3 @@
+Short: Bound Codex startup checks
+
+Codex version and capability checks now run asynchronously with a two-second timeout, preventing a stuck check from freezing the app during startup or terminal restoration. Concurrent callers share checks, and an unavailable version leaves existing Codex configuration unchanged.

--- a/decisions/2026/09/12/bound-codex-startup-probes.md
+++ b/decisions/2026/09/12/bound-codex-startup-probes.md
@@ -1,0 +1,21 @@
+# Bound Codex startup probes
+
+## Context
+
+Two desktop launches stopped logging between Claude and Codex trust preparation while the UI remained on Connecting. The original incident's exact blocking instruction could not be sampled; `codex --version` was an unbounded synchronous operation in that interval, and two sibling `--help` probes had the same failure mode.
+
+## Investigation
+
+A delayed binary through the real version probe prevented every heartbeat tick for 2,245 ms before this change. With the asynchronous implementation, a nonresponsive binary returns unknown after 2,004 ms while 95 heartbeat ticks run; the deadline also covers pipes held open after child exit. See `docs/investigations/2026-09-12-ui-connecting.md` for incident evidence and its limits.
+
+## Decision
+
+`src/bun/codex-config.ts` shares pending version/help probes across startup and launch, drains both streams concurrently, and races the entire operation against a two-second deadline. Failure kills the child with SIGKILL and cancels readers without awaiting their completion; unknown versions skip version-dependent config writes. Launch command assembly and skill installation propagate asynchronous completion through callers.
+
+## Risks
+
+An overloaded or broken executable can exceed the deadline; existing config is retained and help detection uses its existing fallback. Results, including failure, are cached for the process lifetime, matching the previous launch-cache policy; restarting retries detection. Other external commands still need separate deadline audits.
+
+## Alternatives considered
+
+A synchronous timeout still blocks all RPC and heartbeat work for its duration. Racing only child exit leaves inherited output pipes unbounded, and assuming a legacy version on timeout can rewrite a modern configuration incorrectly.

--- a/docs/investigations/2026-09-12-ui-connecting.md
+++ b/docs/investigations/2026-09-12-ui-connecting.md
@@ -1,0 +1,60 @@
+# Desktop startup stuck on Connecting
+
+## Verdict
+
+The September 12 incident is localized to backend startup while restoring the Codex terminal. Two failed desktop processes stop logging immediately after Claude trust completes and before Codex trust completes. The leading suspect is the unbounded synchronous `codex --version` probe inside `ensureCodexTrust`, but the incident's exact blocking instruction is unconfirmed: both failed processes had exited before investigation. No application fix has been applied.
+
+## Evidence
+
+Reviewed the daily application log for 13:35–14:35 local time (Asia/Jerusalem, UTC+3), plus the successful restart immediately afterwards. Source: the installation's `logs/2026/09/2026-09-12.log`. Raw logs and user configuration are intentionally not copied into this repository.
+
+| Local time | Process | Observation |
+| --- | --- | --- |
+| 13:39–14:30 | 14421 | Older instance reports 19 event-loop stalls totaling 142,051 ms; longest 32,633 ms. These belong to a different process and cannot establish the later failures' cause. |
+| 14:32:58 | 87757 | Desktop process starts. |
+| 14:33:03.111 | 87757 | `getPtyUrl` starts restoring the previously selected Codex task. |
+| 14:33:03.209 | 87757 | Last process log: `claude trust ensured`. No Codex trust completion or PTY creation follows. |
+| 14:33:39 | 88802 | Next desktop process starts. |
+| 14:33:41.499 | 88802 | The same task's `getPtyUrl` starts restoration. |
+| 14:33:41.585 | 88802 | Last process log: `claude trust ensured`, again. |
+| 14:33:47 / 14:34:00 | screenshots | First, populated task navigation with Connecting in the terminal; then task navigation also remains loading. |
+| 14:35:28.419–.434 | 89950 | Successful restart crosses Claude → Codex trust in 15 ms. |
+| 14:35:28.518 | 89950 | PTY creation completes. |
+
+Both failed processes successfully answered project/task/settings RPCs before the cutoff. Their logs stop across all categories, consistent with a blocked backend rather than an isolated terminal WebSocket failure. A backend crash or another concurrent blocking operation cannot be excluded using this log alone. The available Bun crash report is from 12:33, outside this incident, with a different PID.
+
+An unrelated stale-worktree cleanup error occurs in the successful restart too; it is not sufficient to explain the freeze.
+
+## Checks performed
+
+- Ran the installed `codex --version` 15 times with an external three-second timeout. All returned `codex-cli 0.154.0` in 9–20 ms.
+- Read the current main Codex config and ran its parser and `ensureCodexConfig` 100 times without writing it. Total: 156 ms; no stall. This does not establish what the files contained during the incident.
+- Invoked the actual `detectCodexVersion` with a temporary PATH fixture named `codex` that sleeps two seconds before printing a version. A 20 ms heartbeat registered **zero ticks over 2,245 ms**. The assertion requiring responsiveness failed (exit 1). This proves a slow child can produce whole-backend unresponsiveness, not that the real child hung during the incident.
+- Confirmed failed PIDs 87757 and 88802 were no longer running. Their stacks cannot be recovered retrospectively.
+
+## Relevant code
+
+- `src/bun/rpc-handlers/tmux-pty.ts`: `launchTaskPty` awaits Claude trust, then Codex trust, before PTY creation.
+- `src/bun/agents.ts`: `ensureCodexTrust` resolves the path, reads/parses the main config, calls `getCodexVersionCached`, patches config and profile files.
+- `src/bun/codex-config.ts`: `detectCodexVersion` calls synchronous `spawnSync(["codex", "--version"])` without a timeout. Startup config installation probes independently, so its successful earlier probe does not populate `agents.ts`'s cache.
+- `src/bun/spawn.ts`: slow-spawn logging happens only after the synchronous call returns.
+- `src/bun/loop-monitor.ts`: the stall monitor uses `setInterval` on the blocked event loop and therefore also reports only after recovery.
+
+## Next capture and repair scope
+
+During the next freeze, leave the application running and capture the backend before restarting it. In a separate terminal, identify the desktop backend (`./bun` whose parent is the desktop launcher):
+
+```sh
+ps -axo pid,ppid,state,etime,pcpu,comm
+```
+
+Then replace `BACKEND_PID` below with that numeric PID:
+
+```sh
+sample BACKEND_PID 5 -file /tmp/dev3-connecting-sample.txt
+ps -axo pid,ppid,state,etime,pcpu,comm > /tmp/dev3-connecting-processes.txt
+```
+
+The sample distinguishes a child-process wait from parsing, filesystem I/O, and unrelated synchronous work. These files are local diagnostics and should be reviewed before public sharing.
+
+The justified hardening direction is to move external Codex capability/version probes off the main event loop, bound their duration, drain child output concurrently, and share the probe result across startup and launch. A regression test should verify that a deliberately nonresponsive binary cannot stop unrelated RPC work and cannot leave restoration pending forever. Merely catching exceptions or caching the first synchronous call leaves the first-launch failure intact. File-stage timings would improve attribution, but timers within the backend cannot diagnose a permanently blocked backend by themselves.

--- a/docs/investigations/2026-09-12-ui-connecting.md
+++ b/docs/investigations/2026-09-12-ui-connecting.md
@@ -2,7 +2,7 @@
 
 ## Verdict
 
-The September 12 incident is localized to backend startup while restoring the Codex terminal. Two failed desktop processes stop logging immediately after Claude trust completes and before Codex trust completes. The leading suspect is the unbounded synchronous `codex --version` probe inside `ensureCodexTrust`, but the incident's exact blocking instruction is unconfirmed: both failed processes had exited before investigation. No application fix has been applied.
+The September 12 incident is localized to backend startup while restoring the Codex terminal. Two failed desktop processes stop logging immediately after Claude trust completes and before Codex trust completes. The leading suspect is the unbounded synchronous `codex --version` probe inside `ensureCodexTrust`, but the incident's exact blocking instruction is unconfirmed: both failed processes had exited before investigation. The follow-up patch now bounds Codex version/help probes asynchronously; it addresses the reproduced failure mechanism without claiming a sampled root cause for the original incident.
 
 ## Evidence
 
@@ -58,3 +58,25 @@ ps -axo pid,ppid,state,etime,pcpu,comm > /tmp/dev3-connecting-processes.txt
 The sample distinguishes a child-process wait from parsing, filesystem I/O, and unrelated synchronous work. These files are local diagnostics and should be reviewed before public sharing.
 
 The justified hardening direction is to move external Codex capability/version probes off the main event loop, bound their duration, drain child output concurrently, and share the probe result across startup and launch. A regression test should verify that a deliberately nonresponsive binary cannot stop unrelated RPC work and cannot leave restoration pending forever. Merely catching exceptions or caching the first synchronous call leaves the first-launch failure intact. File-stage timings would improve attribution, but timers within the backend cannot diagnose a permanently blocked backend by themselves.
+
+
+## Implemented hardening
+
+The version and help probes now share pending results, run asynchronously, and have a two-second deadline covering process exit and both output streams. Unknown versions leave existing config unchanged. A real Bun process with a deliberately nonresponsive executable returned unknown after 2,004 ms while 95 heartbeat ticks ran (exit 0); the previous synchronous probe produced zero ticks over 2,245 ms (exit 1).
+
+## Adjacent execution audit
+
+A separate OpenAI subagent performed the requested read-only scan; xAI was not available in this harness. These are code-level risks, not additional proven causes of the incident:
+
+| Area | Reachable risk | Follow-up |
+| --- | --- | --- |
+| Codex help | `codex-config.ts`: two synchronous unbounded capability probes on launch | Included in this patch. |
+| Account shell | `shell-env.ts`, `readAccountShell`: synchronous `dscl` / `getent`, reached at startup and after cache expiry | Bounded asynchronous discovery. |
+| Login shell environment | `shell-env.ts`, `runEnvDump`: SIGTERM timer does not bound exit or subsequent pipe reads | Bound exit plus concurrent pipe collection, with hard termination. |
+| Windows shortcuts | `windows-shortcuts/powershell-surface.ts`: synchronous PowerShell/COM operations at startup | Bound optional reconciliation and skip on failure. |
+| GitHub auth | `github.ts`: auth commands run before the enclosing operation deadline | Cover authentication with the deadline. |
+| Account credentials | `agent-accounts.ts`: `security find-generic-password` without deadline, undrained stderr | Bound credential collection with allowance for permission interaction. |
+| Process inspection | `worktree-reaper.ts` / `process-reaper.ts`: unbounded `lsof` during cleanup | Bound inspection; timeout must not be interpreted as no processes. |
+| User activity | `user-activity.ts`: unbounded `ioreg` in activity requests | Small deadline with unknown-activity fallback. |
+
+The remaining sites are intentionally separate follow-up scope. Their differing failure semantics need targeted tests; bulk-adding a timer can silently make cleanup or credential handling incorrect.

--- a/src/bun/__tests__/agent-command-golden.test.ts
+++ b/src/bun/__tests__/agent-command-golden.test.ts
@@ -239,8 +239,8 @@ describe("resolveAgentCommand — golden matrix (structural, byte-identical)", (
 		expect([...caseNames].sort()).toEqual([...expectedNames].sort());
 	});
 
-	it.each(cases.map((c) => [c.name, c] as const))("%s", (_name, c) => {
-		const out = resolveAgentCommand(agent(c.base), c.config, c.ctx ?? CTX, c.options);
+	it.each(cases.map((c) => [c.name, c] as const))("%s", async (_name, c) => {
+		const out = await resolveAgentCommand(agent(c.base), c.config, c.ctx ?? CTX, c.options);
 		expect(redact(out)).toBe(EXPECTED[c.name]);
 	});
 });

--- a/src/bun/__tests__/agent-command-line-budget.test.ts
+++ b/src/bun/__tests__/agent-command-line-budget.test.ts
@@ -105,11 +105,11 @@ vi.mock("../agent-system-prompt-file", async () => {
 
 describe("the whole Windows command line fits", () => {
 	for (const command of AGENT_COMMANDS) {
-		it(`${command} launches inside the ceiling with a full-size task`, () => {
+		it(`${command} launches inside the ceiling with a full-size task`, async () => {
 			asPlatform("win32");
 			__setCodexProfileV2Override(false);
 			try {
-				const cmd = resolveAgentCommand(agent(command), undefined, fullSizeContext());
+				const cmd = await resolveAgentCommand(agent(command), undefined, fullSizeContext());
 				expect(cmd.length).toBeLessThan(WINDOWS_COMMAND_LINE_LIMIT);
 			} finally {
 				__setCodexProfileV2Override(null);
@@ -132,16 +132,16 @@ describe("the whole Windows command line fits", () => {
 	// The create-and-launch default (2026-09-12) was folded into the rules it
 	// belongs to and paid for out of illustrations and justifications, so these two
 	// numbers did not move.
-	it("a coordinator task keeps the launch room it had before the events block", () => {
+	it("a coordinator task keeps the launch room it had before the events block", async () => {
 		asPlatform("win32");
 		const coordinator = (brief: number) => ({
 			...fullSizeContext(),
 			taskDescription: `${COORDINATOR_PROMPT}\n\n${"x".repeat(brief)}`,
 		});
-		const fits = (command: string, brief: number) =>
-			resolveAgentCommand(agent(command), undefined, coordinator(brief)).length < WINDOWS_COMMAND_LINE_LIMIT;
-		expect(fits("gemini", 26536)).toBe(true);
-		expect(fits("some-custom-agent", 26525)).toBe(true);
+		const fits = async (command: string, brief: number) =>
+			(await resolveAgentCommand(agent(command), undefined, coordinator(brief))).length < WINDOWS_COMMAND_LINE_LIMIT;
+		expect(await fits("gemini", 26536)).toBe(true);
+		expect(await fits("some-custom-agent", 26525)).toBe(true);
 	});
 
 	it("the reserve is real: a task text this long is what the budget is for", () => {

--- a/src/bun/__tests__/agent-launch-args.test.ts
+++ b/src/bun/__tests__/agent-launch-args.test.ts
@@ -124,22 +124,22 @@ describe("commandToken", () => {
 });
 
 describe("the launch call site", () => {
-	it("resolveAgentCommand emits no POSIX escape on Windows", () => {
+	it("resolveAgentCommand emits no POSIX escape on Windows", async () => {
 		// Not a synthetic string: this is the prompt every Claude launch carries,
 		// and the apostrophes in it are what killed the .ps1 parse. On Windows it
 		// now travels as a file (the ceiling below), so what must be gone from the
 		// command line is the POSIX escape — in the prompt and everywhere else.
 		expect(DEV3_SYSTEM_PROMPT).toContain("'");
 		asPlatform("win32");
-		const cmd = resolveAgentCommand(agent("claude"), undefined, CTX);
+		const cmd = await resolveAgentCommand(agent("claude"), undefined, CTX);
 		expect(cmd).toContain("--append-system-prompt-file");
 		expect(cmd).not.toContain("'\\''");
 		expect(cmd).toContain(powerShellNativeArg("Fix the login bug"));
 	});
 
-	it("resolveAgentCommand uses the file on POSIX too, and still quotes the rest the POSIX way", () => {
+	it("resolveAgentCommand uses the file on POSIX too, and still quotes the rest the POSIX way", async () => {
 		asPlatform("darwin");
-		const cmd = resolveAgentCommand(agent("claude"), undefined, CTX);
+		const cmd = await resolveAgentCommand(agent("claude"), undefined, CTX);
 		// The protocol body no longer sits in argv (#1734): its own single quotes
 		// used to show up here as the '\'' escape sequence.
 		expect(cmd).toContain("--append-system-prompt-file");
@@ -147,17 +147,17 @@ describe("the launch call site", () => {
 		expect(cmd).toContain("'Fix the login bug'");
 	});
 
-	it("the POSIX escape is still emitted — now for the user's own apostrophes", () => {
+	it("the POSIX escape is still emitted — now for the user's own apostrophes", async () => {
 		// The protocol used to supply them; with it gone from argv the guard has to
 		// be proved on the task text, or it would quietly stop guarding anything.
 		asPlatform("darwin");
-		const cmd = resolveAgentCommand(agent("claude"), undefined, { ...CTX, taskDescription: "the task's title" });
+		const cmd = await resolveAgentCommand(agent("claude"), undefined, { ...CTX, taskDescription: "the task's title" });
 		expect(cmd).toContain("'\\''");
 	});
 
-	it("resolveAgentCommand spells a resolved binary path as a command", () => {
+	it("resolveAgentCommand spells a resolved binary path as a command", async () => {
 		asPlatform("win32");
-		const cmd = resolveAgentCommand(agent("C:\\Users\\John Smith\\bin\\claude.exe"), undefined, CTX);
+		const cmd = await resolveAgentCommand(agent("C:\\Users\\John Smith\\bin\\claude.exe"), undefined, CTX);
 		expect(cmd.startsWith("& 'C:\\Users\\John Smith\\bin\\claude.exe' ")).toBe(true);
 	});
 
@@ -183,10 +183,10 @@ describe("the command-line ceiling", () => {
 		expect(CLAUDE_SKILL_BODY.length).toBeGreaterThan(WINDOWS_COMMAND_LINE_LIMIT / 2);
 	});
 
-	it("every platform gets the file — the ceiling on Windows, argv exposure everywhere", () => {
+	it("every platform gets the file — the ceiling on Windows, argv exposure everywhere", async () => {
 		for (const platform of ["win32", "darwin", "linux"] as const) {
 			asPlatform(platform);
-			const cmd = resolveAgentCommand(agent("claude"), undefined, CTX);
+			const cmd = await resolveAgentCommand(agent("claude"), undefined, CTX);
 			expect(cmd, platform).toContain("--append-system-prompt-file");
 			expect(cmd.length, platform).toBeLessThan(WINDOWS_COMMAND_LINE_LIMIT);
 		}

--- a/src/bun/__tests__/agent-skills-install.test.ts
+++ b/src/bun/__tests__/agent-skills-install.test.ts
@@ -54,7 +54,7 @@ describe("installAgentSkills", () => {
 		);
 
 		const { installAgentSkills, ensureCodexConfigFile } = await loadModule();
-		installAgentSkills();
+		await installAgentSkills();
 
 		expect(existsSync(join(tempHome, ".agents/skills/dev3/SKILL.md"))).toBe(true);
 		expect(existsSync(join(tempHome, ".agents/skills/dev3-project-config/SKILL.md"))).toBe(true);
@@ -84,14 +84,14 @@ describe("installAgentSkills", () => {
 
 	it("can defer Codex config patching until the shell PATH is resolved", async () => {
 		const { installAgentSkills, ensureCodexConfigFile } = await loadModule();
-		installAgentSkills({ configureCodex: false });
+		await installAgentSkills({ configureCodex: false });
 
 		expect(ensureCodexConfigFile).not.toHaveBeenCalled();
 	});
 
 	it("writes the full-protocol PROTOCOL.md fallback next to the short Claude SKILL.md", async () => {
 		const { installAgentSkills } = await loadModule();
-		installAgentSkills();
+		await installAgentSkills();
 
 		expect(existsSync(join(tempHome, ".claude/skills/dev3/SKILL.md"))).toBe(true);
 		expect(existsSync(join(tempHome, ".claude/skills/dev3/PROTOCOL.md"))).toBe(true);
@@ -99,7 +99,7 @@ describe("installAgentSkills", () => {
 
 	it("keeps shared AGENTS.md neutral about hook-owned versus manual lifecycle", async () => {
 		const { installAgentSkills } = await loadModule();
-		installAgentSkills();
+		await installAgentSkills();
 
 		const agentsMd = readFileSync(join(tempHome, ".agents/AGENTS.md"), "utf-8");
 		expect(agentsMd).toContain("Follow the agent-specific status section in the loaded dev3 skill");
@@ -117,7 +117,7 @@ describe("installAgentSkills", () => {
 		writeFileSync(join(tempHome, ".agents/AGENTS.md"), "# My own notes\n\nKeep these.\n", "utf-8");
 
 		const { installAgentSkills } = await loadModule();
-		installAgentSkills({ lowBattery: true });
+		await installAgentSkills({ lowBattery: true });
 
 		const agentsMd = readFileSync(join(tempHome, ".agents/AGENTS.md"), "utf-8");
 		expect(agentsMd).toContain("# My own notes");
@@ -130,9 +130,9 @@ describe("installAgentSkills", () => {
 
 	it("stays a single managed block across repeated installs", async () => {
 		const { installAgentSkills } = await loadModule();
-		installAgentSkills({ lowBattery: true });
-		installAgentSkills({ lowBattery: true });
-		installAgentSkills({ lowBattery: true });
+		await installAgentSkills({ lowBattery: true });
+		await installAgentSkills({ lowBattery: true });
+		await installAgentSkills({ lowBattery: true });
 
 		const agentsMd = readFileSync(join(tempHome, ".agents/AGENTS.md"), "utf-8");
 		expect(agentsMd.match(/<!-- dev3:start -->/g)).toHaveLength(1);
@@ -142,10 +142,10 @@ describe("installAgentSkills", () => {
 
 	it("takes the always-on line back out when low-battery is switched off", async () => {
 		const { installAgentSkills } = await loadModule();
-		installAgentSkills({ lowBattery: true });
+		await installAgentSkills({ lowBattery: true });
 		expect(readFileSync(join(tempHome, ".agents/AGENTS.md"), "utf-8")).toContain("low-battery");
 
-		installAgentSkills({ lowBattery: false });
+		await installAgentSkills({ lowBattery: false });
 
 		const agentsMd = readFileSync(join(tempHome, ".agents/AGENTS.md"), "utf-8");
 		expect(agentsMd).not.toContain("low-battery");
@@ -157,11 +157,11 @@ describe("installAgentSkills", () => {
 
 	it("installs low-battery on an explicit opt-in and removes it on an explicit opt-out", async () => {
 		const { installAgentSkills } = await loadModule();
-		installAgentSkills({ lowBattery: true });
+		await installAgentSkills({ lowBattery: true });
 		expect(existsSync(join(tempHome, ".agents/skills/low-battery/SKILL.md"))).toBe(true);
 		expect(existsSync(join(tempHome, ".claude/output-styles/low-battery.md"))).toBe(true);
 
-		installAgentSkills({ lowBattery: false });
+		await installAgentSkills({ lowBattery: false });
 		expect(existsSync(join(tempHome, ".agents/skills/low-battery/SKILL.md"))).toBe(false);
 		expect(existsSync(join(tempHome, ".claude/output-styles/low-battery.md"))).toBe(false);
 		// dev3's own skills are untouched by the low-battery toggle.
@@ -173,7 +173,7 @@ describe("installAgentSkills", () => {
 	 */
 	it("installs nothing when no choice is stored", async () => {
 		const { installAgentSkills } = await loadModule();
-		installAgentSkills();
+		await installAgentSkills();
 
 		expect(existsSync(join(tempHome, ".agents/skills/low-battery"))).toBe(false);
 		expect(existsSync(join(tempHome, ".claude/output-styles/low-battery.md"))).toBe(false);
@@ -192,7 +192,7 @@ describe("installAgentSkills", () => {
 		mkdirSync(ownSkill, { recursive: true });
 		writeFileSync(join(ownSkill, "SKILL.md"), "my own copy", "utf-8");
 
-		installAgentSkills();
+		await installAgentSkills();
 
 		expect(readFileSync(join(ownSkill, "SKILL.md"), "utf-8")).toBe("my own copy");
 	});

--- a/src/bun/__tests__/agents.test.ts
+++ b/src/bun/__tests__/agents.test.ts
@@ -79,8 +79,8 @@ describe("supportsResume", () => {
 
 describe("resolveAgentCommand — resume", () => {
 	// ---- Claude ----
-	it("Claude: adds --continue and skips prompt when resume=true", () => {
-		const cmd = resolveAgentCommand(
+	it("Claude: adds --continue and skips prompt when resume=true", async () => {
+		const cmd = await resolveAgentCommand(
 			makeAgent({ baseCommand: "claude" }),
 			makeConfig(),
 			makeCtx({ taskDescription: "Some task description" }),
@@ -91,8 +91,8 @@ describe("resolveAgentCommand — resume", () => {
 		expect(cmd).not.toContain("Some task description");
 	});
 
-	it("Claude: includes prompt normally when resume is not set", () => {
-		const cmd = resolveAgentCommand(
+	it("Claude: includes prompt normally when resume is not set", async () => {
+		const cmd = await resolveAgentCommand(
 			makeAgent({ baseCommand: "claude" }),
 			makeConfig(),
 			makeCtx({ taskDescription: "Some task description" }),
@@ -102,8 +102,8 @@ describe("resolveAgentCommand — resume", () => {
 		expect(cmd).toContain("Some task description");
 	});
 
-	it("Claude: skips appendPrompt when resume=true", () => {
-		const cmd = resolveAgentCommand(
+	it("Claude: skips appendPrompt when resume=true", async () => {
+		const cmd = await resolveAgentCommand(
 			makeAgent({ baseCommand: "claude" }),
 			makeConfig({ appendPrompt: "Extra instructions: {{TASK_TITLE}}" }),
 			makeCtx({ taskDescription: "" }),
@@ -114,8 +114,8 @@ describe("resolveAgentCommand — resume", () => {
 		expect(cmd).not.toContain("Extra instructions");
 	});
 
-	it("Claude: the protocol body travels as a file on POSIX too, not in argv (#1734)", () => {
-		const cmd = resolveAgentCommand(makeAgent({ baseCommand: "claude" }), makeConfig(), makeCtx());
+	it("Claude: the protocol body travels as a file on POSIX too, not in argv (#1734)", async () => {
+		const cmd = await resolveAgentCommand(makeAgent({ baseCommand: "claude" }), makeConfig(), makeCtx());
 
 		expect(cmd).toContain("--append-system-prompt-file");
 		expect(cmd).not.toContain("--append-system-prompt '");
@@ -124,8 +124,8 @@ describe("resolveAgentCommand — resume", () => {
 		expect(readFileSync(join(AGENT_PROMPTS_DIR, "claude.md"), "utf-8")).toBe(CLAUDE_SKILL_BODY);
 	});
 
-	it("Claude: still includes --append-system-prompt when resume=true", () => {
-		const cmd = resolveAgentCommand(
+	it("Claude: still includes --append-system-prompt when resume=true", async () => {
+		const cmd = await resolveAgentCommand(
 			makeAgent({ baseCommand: "claude" }),
 			makeConfig(),
 			makeCtx(),
@@ -136,8 +136,8 @@ describe("resolveAgentCommand — resume", () => {
 	});
 
 	// ---- Codex ----
-	it("Codex: uses 'codex resume --last' subcommand when resume=true", () => {
-		const cmd = resolveAgentCommand(
+	it("Codex: uses 'codex resume --last' subcommand when resume=true", async () => {
+		const cmd = await resolveAgentCommand(
 			makeAgent({ baseCommand: "codex" }),
 			makeConfig({ model: undefined }),
 			makeCtx({ taskDescription: "Some task" }),
@@ -148,8 +148,8 @@ describe("resolveAgentCommand — resume", () => {
 		expect(cmd).not.toContain("Some task");
 	});
 
-	it("Codex: ignores unsupported generic config flags during resume", () => {
-		const cmd = resolveAgentCommand(
+	it("Codex: ignores unsupported generic config flags during resume", async () => {
+		const cmd = await resolveAgentCommand(
 			makeAgent({ baseCommand: "codex" }),
 			makeConfig({
 				model: "gpt-5",
@@ -168,8 +168,8 @@ describe("resolveAgentCommand — resume", () => {
 		expect(cmd).not.toContain("--max-budget-usd");
 	});
 
-	it("Codex: normal command when resume is not set", () => {
-		const cmd = resolveAgentCommand(
+	it("Codex: normal command when resume is not set", async () => {
+		const cmd = await resolveAgentCommand(
 			makeAgent({ baseCommand: "codex" }),
 			makeConfig({ model: undefined }),
 			makeCtx({ taskDescription: "Some task" }),
@@ -180,8 +180,8 @@ describe("resolveAgentCommand — resume", () => {
 		expect(cmd).toContain("Some task");
 	});
 
-	it("Claude: quotes model names containing shell metacharacters", () => {
-		const cmd = resolveAgentCommand(
+	it("Claude: quotes model names containing shell metacharacters", async () => {
+		const cmd = await resolveAgentCommand(
 			makeAgent({ baseCommand: "claude" }),
 			makeConfig({ model: "claude-opus-4-8[1m]" }),
 			makeCtx({ taskDescription: "Some task" }),
@@ -191,8 +191,8 @@ describe("resolveAgentCommand — resume", () => {
 		expect(cmd).not.toContain("--model claude-opus-4-8[1m]");
 	});
 
-	it("omits --model when a third-party provider is selected for the launch", () => {
-		const cmd = resolveAgentCommand(
+	it("omits --model when a third-party provider is selected for the launch", async () => {
+		const cmd = await resolveAgentCommand(
 			makeAgent({ baseCommand: "claude" }),
 			makeConfig({ model: "claude-opus-4-8[1m]" }),
 			makeCtx({ taskDescription: "Some task" }),
@@ -202,8 +202,8 @@ describe("resolveAgentCommand — resume", () => {
 		expect(cmd).not.toContain("--model");
 	});
 
-	it("Codex on Bedrock: keeps --model and appends the model_provider routing args", () => {
-		const cmd = resolveAgentCommand(
+	it("Codex on Bedrock: keeps --model and appends the model_provider routing args", async () => {
+		const cmd = await resolveAgentCommand(
 			makeAgent({ baseCommand: "codex" }),
 			makeConfig({ model: "global.openai.gpt-5.6-sol" }),
 			makeCtx({ taskDescription: "Some task" }),
@@ -215,8 +215,8 @@ describe("resolveAgentCommand — resume", () => {
 		expect(cmd).toContain(`-c 'model_provider="amazon-bedrock-runtime"'`);
 	});
 
-	it("keeps --model when no provider is selected (native default)", () => {
-		const cmd = resolveAgentCommand(
+	it("keeps --model when no provider is selected (native default)", async () => {
+		const cmd = await resolveAgentCommand(
 			makeAgent({ baseCommand: "claude" }),
 			makeConfig({ model: "claude-opus-4-8[1m]" }),
 			makeCtx({ taskDescription: "Some task" }),
@@ -224,8 +224,8 @@ describe("resolveAgentCommand — resume", () => {
 		expect(cmd).toContain("--model 'claude-opus-4-8[1m]'");
 	});
 
-	it("Codex: injects the dev3 protocol via -c developer_instructions, not the prompt", () => {
-		const cmd = resolveAgentCommand(
+	it("Codex: injects the dev3 protocol via -c developer_instructions, not the prompt", async () => {
+		const cmd = await resolveAgentCommand(
 			makeAgent({ baseCommand: "codex" }),
 			makeConfig({ model: undefined }),
 			makeCtx({ taskDescription: "Some task" }),
@@ -244,8 +244,8 @@ describe("resolveAgentCommand — resume", () => {
 		expect(cmd).toContain("-- 'Some task'");
 	});
 
-	it("Codex: resume also carries -c developer_instructions", () => {
-		const cmd = resolveAgentCommand(
+	it("Codex: resume also carries -c developer_instructions", async () => {
+		const cmd = await resolveAgentCommand(
 			makeAgent({ baseCommand: "codex" }),
 			makeConfig({ model: undefined }),
 			makeCtx({ taskDescription: "Some task" }),
@@ -256,8 +256,8 @@ describe("resolveAgentCommand — resume", () => {
 		expect(cmd).toContain("-c 'developer_instructions=");
 	});
 
-	it("Codex: skipSystemPrompt suppresses -c developer_instructions", () => {
-		const cmd = resolveAgentCommand(
+	it("Codex: skipSystemPrompt suppresses -c developer_instructions", async () => {
+		const cmd = await resolveAgentCommand(
 			makeAgent({ baseCommand: "codex" }),
 			makeConfig({ model: undefined }),
 			makeCtx({ taskDescription: "Some task" }),
@@ -268,10 +268,10 @@ describe("resolveAgentCommand — resume", () => {
 		expect(cmd).not.toContain("Task Lifecycle Protocol");
 	});
 
-	it("Codex: uses dracula theme when dev3 UI theme is dark", () => {
+	it("Codex: uses dracula theme when dev3 UI theme is dark", async () => {
 		setCurrentUiTheme("dark");
 
-		const cmd = resolveAgentCommand(
+		const cmd = await resolveAgentCommand(
 			makeAgent({ baseCommand: "codex" }),
 			makeConfig({ model: undefined, additionalArgs: ["-p", "dev3"] }),
 			makeCtx({ taskDescription: "Some task" }),
@@ -282,10 +282,10 @@ describe("resolveAgentCommand — resume", () => {
 		expect(cmd).toContain(`-c 'tui.theme="dracula"'`);
 	});
 
-	it("Codex: uses github theme when dev3 UI theme is light", () => {
+	it("Codex: uses github theme when dev3 UI theme is light", async () => {
 		setCurrentUiTheme("light");
 
-		const cmd = resolveAgentCommand(
+		const cmd = await resolveAgentCommand(
 			makeAgent({ baseCommand: "codex" }),
 			makeConfig({ model: undefined, additionalArgs: ["-p", "dev3"] }),
 			makeCtx({ taskDescription: "Some task" }),
@@ -296,8 +296,8 @@ describe("resolveAgentCommand — resume", () => {
 		expect(cmd).toContain(`-c 'tui.theme="github"'`);
 	});
 
-	it("Codex: preserves unrelated config overrides when injecting the theme", () => {
-		const cmd = resolveAgentCommand(
+	it("Codex: preserves unrelated config overrides when injecting the theme", async () => {
+		const cmd = await resolveAgentCommand(
 			makeAgent({ baseCommand: "codex" }),
 			makeConfig({
 				model: undefined,
@@ -312,8 +312,8 @@ describe("resolveAgentCommand — resume", () => {
 		expect(cmd).toContain(`-c 'tui.theme="dracula"'`);
 	});
 
-	it("Codex: appends the dev3 theme after a conflicting user override", () => {
-		const cmd = resolveAgentCommand(
+	it("Codex: appends the dev3 theme after a conflicting user override", async () => {
+		const cmd = await resolveAgentCommand(
 			makeAgent({ baseCommand: "codex" }),
 			makeConfig({
 				model: undefined,
@@ -325,10 +325,10 @@ describe("resolveAgentCommand — resume", () => {
 		expect(cmd.indexOf('tui.theme="nord"')).toBeLessThan(cmd.indexOf('tui.theme="dracula"'));
 	});
 
-	it("Codex: leaves custom profile names untouched", () => {
+	it("Codex: leaves custom profile names untouched", async () => {
 		setCurrentUiTheme("light");
 
-		const cmd = resolveAgentCommand(
+		const cmd = await resolveAgentCommand(
 			makeAgent({ baseCommand: "codex" }),
 			makeConfig({ model: undefined, additionalArgs: ["-p", "my-custom-profile"] }),
 			makeCtx({ taskDescription: "Some task" }),
@@ -338,11 +338,11 @@ describe("resolveAgentCommand — resume", () => {
 		expect(cmd).not.toContain("-p dev3-light");
 	});
 
-	it("Codex: rewrites -p to --profile-v2 on profile-v2 Codex (dark)", () => {
+	it("Codex: rewrites -p to --profile-v2 on profile-v2 Codex (dark)", async () => {
 		setCurrentUiTheme("dark");
 		__setCodexProfileV2Override(true);
 
-		const cmd = resolveAgentCommand(
+		const cmd = await resolveAgentCommand(
 			makeAgent({ baseCommand: "codex" }),
 			makeConfig({ model: undefined, additionalArgs: ["-p", "dev3"] }),
 			makeCtx({ taskDescription: "Some task" }),
@@ -353,11 +353,11 @@ describe("resolveAgentCommand — resume", () => {
 		expect(cmd).not.toContain("-p dev3 ");
 	});
 
-	it("Codex: rewrites --profile to --profile-v2 on profile-v2 Codex (light)", () => {
+	it("Codex: rewrites --profile to --profile-v2 on profile-v2 Codex (light)", async () => {
 		setCurrentUiTheme("light");
 		__setCodexProfileV2Override(true);
 
-		const cmd = resolveAgentCommand(
+		const cmd = await resolveAgentCommand(
 			makeAgent({ baseCommand: "codex" }),
 			makeConfig({ model: undefined, additionalArgs: ["--profile", "dev3"] }),
 			makeCtx({ taskDescription: "Some task" }),
@@ -367,11 +367,11 @@ describe("resolveAgentCommand — resume", () => {
 		expect(cmd).not.toContain("--profile dev3-light");
 	});
 
-	it("Codex: leaves custom profile names untouched on profile-v2 Codex", () => {
+	it("Codex: leaves custom profile names untouched on profile-v2 Codex", async () => {
 		setCurrentUiTheme("dark");
 		__setCodexProfileV2Override(true);
 
-		const cmd = resolveAgentCommand(
+		const cmd = await resolveAgentCommand(
 			makeAgent({ baseCommand: "codex" }),
 			makeConfig({ model: undefined, additionalArgs: ["-p", "my-custom-profile"] }),
 			makeCtx({ taskDescription: "Some task" }),
@@ -381,13 +381,13 @@ describe("resolveAgentCommand — resume", () => {
 		expect(cmd).not.toContain("--profile-v2");
 	});
 
-	it("Codex: never emits --profile-v2 on newer codex that removed it (issue #611)", () => {
+	it("Codex: never emits --profile-v2 on newer codex that removed it (issue #611)", async () => {
 		setCurrentUiTheme("dark");
 		// false => launch flag is the post-rename `--profile`, so the user's `-p`
 		// must be kept as-is and `--profile-v2` must never appear (it aborts codex).
 		__setCodexProfileV2Override(false);
 
-		const cmd = resolveAgentCommand(
+		const cmd = await resolveAgentCommand(
 			makeAgent({ baseCommand: "codex" }),
 			makeConfig({ model: undefined, additionalArgs: ["-p", "dev3"] }),
 			makeCtx({ taskDescription: "Some task" }),
@@ -398,8 +398,8 @@ describe("resolveAgentCommand — resume", () => {
 	});
 
 	// ---- Gemini ----
-	it("Gemini: adds --resume latest when resume=true", () => {
-		const cmd = resolveAgentCommand(
+	it("Gemini: adds --resume latest when resume=true", async () => {
+		const cmd = await resolveAgentCommand(
 			makeAgent({ baseCommand: "gemini" }),
 			makeConfig({ model: undefined }),
 			makeCtx({ taskDescription: "Some task" }),
@@ -410,8 +410,8 @@ describe("resolveAgentCommand — resume", () => {
 		expect(cmd).not.toContain("Some task");
 	});
 
-	it("Gemini: normal command when resume is not set", () => {
-		const cmd = resolveAgentCommand(
+	it("Gemini: normal command when resume is not set", async () => {
+		const cmd = await resolveAgentCommand(
 			makeAgent({ baseCommand: "gemini" }),
 			makeConfig({ model: undefined }),
 			makeCtx({ taskDescription: "Some task" }),
@@ -422,8 +422,8 @@ describe("resolveAgentCommand — resume", () => {
 	});
 
 	// ---- Cursor Agent ----
-	it("Cursor Agent: adds --continue when resume=true", () => {
-		const cmd = resolveAgentCommand(
+	it("Cursor Agent: adds --continue when resume=true", async () => {
+		const cmd = await resolveAgentCommand(
 			makeAgent({ baseCommand: "agent" }),
 			makeConfig({ model: undefined }),
 			makeCtx({ taskDescription: "Some task" }),
@@ -434,8 +434,8 @@ describe("resolveAgentCommand — resume", () => {
 		expect(cmd).not.toContain("Some task");
 	});
 
-	it("Cursor Agent: normal command when resume is not set", () => {
-		const cmd = resolveAgentCommand(
+	it("Cursor Agent: normal command when resume is not set", async () => {
+		const cmd = await resolveAgentCommand(
 			makeAgent({ baseCommand: "agent" }),
 			makeConfig({ model: undefined }),
 			makeCtx({ taskDescription: "Some task" }),
@@ -448,8 +448,8 @@ describe("resolveAgentCommand — resume", () => {
 	});
 
 	// ---- skipSystemPrompt ----
-	it("Claude: skips --append-system-prompt when skipSystemPrompt=true", () => {
-		const cmd = resolveAgentCommand(
+	it("Claude: skips --append-system-prompt when skipSystemPrompt=true", async () => {
+		const cmd = await resolveAgentCommand(
 			makeAgent({ baseCommand: "claude" }),
 			makeConfig(),
 			makeCtx(),
@@ -460,8 +460,8 @@ describe("resolveAgentCommand — resume", () => {
 		expect(cmd).not.toContain("Task Lifecycle Protocol");
 	});
 
-	it("Claude: includes --append-system-prompt by default", () => {
-		const cmd = resolveAgentCommand(
+	it("Claude: includes --append-system-prompt by default", async () => {
+		const cmd = await resolveAgentCommand(
 			makeAgent({ baseCommand: "claude" }),
 			makeConfig(),
 			makeCtx(),
@@ -470,8 +470,8 @@ describe("resolveAgentCommand — resume", () => {
 		expect(cmd).toContain("--append-system-prompt");
 	});
 
-	it("Claude: includes --append-system-prompt when skipSystemPrompt=false", () => {
-		const cmd = resolveAgentCommand(
+	it("Claude: includes --append-system-prompt when skipSystemPrompt=false", async () => {
+		const cmd = await resolveAgentCommand(
 			makeAgent({ baseCommand: "claude" }),
 			makeConfig(),
 			makeCtx(),
@@ -482,8 +482,8 @@ describe("resolveAgentCommand — resume", () => {
 	});
 
 	// ---- OpenCode ----
-	it("OpenCode: adds --continue when resume=true", () => {
-		const cmd = resolveAgentCommand(
+	it("OpenCode: adds --continue when resume=true", async () => {
+		const cmd = await resolveAgentCommand(
 			makeAgent({ baseCommand: "opencode" }),
 			makeConfig({ model: "anthropic/claude-opus-4-6" }),
 			makeCtx({ taskDescription: "Some task" }),
@@ -494,8 +494,8 @@ describe("resolveAgentCommand — resume", () => {
 		expect(cmd).not.toContain("Some task");
 	});
 
-	it("OpenCode: uses --prompt flag for prompt (not positional)", () => {
-		const cmd = resolveAgentCommand(
+	it("OpenCode: uses --prompt flag for prompt (not positional)", async () => {
+		const cmd = await resolveAgentCommand(
 			makeAgent({ baseCommand: "opencode" }),
 			makeConfig({ model: "anthropic/claude-opus-4-6" }),
 			makeCtx({ taskDescription: "Fix the login bug" }),
@@ -506,8 +506,8 @@ describe("resolveAgentCommand — resume", () => {
 		expect(cmd).toContain("--model anthropic/claude-opus-4-6");
 	});
 
-	it("OpenCode: injects generic system prompt (not Claude hooks variant)", () => {
-		const cmd = resolveAgentCommand(
+	it("OpenCode: injects generic system prompt (not Claude hooks variant)", async () => {
+		const cmd = await resolveAgentCommand(
 			makeAgent({ baseCommand: "opencode" }),
 			makeConfig({ model: undefined }),
 			makeCtx({ taskDescription: "Some task" }),
@@ -520,8 +520,8 @@ describe("resolveAgentCommand — resume", () => {
 		expect(cmd).not.toContain("Hooks automatically manage task status");
 	});
 
-	it("OpenCode: does not emit --permission-mode, --effort, or --max-budget-usd", () => {
-		const cmd = resolveAgentCommand(
+	it("OpenCode: does not emit --permission-mode, --effort, or --max-budget-usd", async () => {
+		const cmd = await resolveAgentCommand(
 			makeAgent({ baseCommand: "opencode" }),
 			makeConfig({
 				model: "anthropic/claude-opus-4-6",
@@ -537,8 +537,8 @@ describe("resolveAgentCommand — resume", () => {
 		expect(cmd).not.toContain("--max-budget-usd");
 	});
 
-	it("OpenCode: does not emit --append-system-prompt", () => {
-		const cmd = resolveAgentCommand(
+	it("OpenCode: does not emit --append-system-prompt", async () => {
+		const cmd = await resolveAgentCommand(
 			makeAgent({ baseCommand: "opencode" }),
 			makeConfig(),
 			makeCtx(),
@@ -547,8 +547,8 @@ describe("resolveAgentCommand — resume", () => {
 		expect(cmd).not.toContain("--append-system-prompt");
 	});
 
-	it("OpenCode: passes additionalArgs (e.g. --agent sisyphus)", () => {
-		const cmd = resolveAgentCommand(
+	it("OpenCode: passes additionalArgs (e.g. --agent sisyphus)", async () => {
+		const cmd = await resolveAgentCommand(
 			makeAgent({ baseCommand: "opencode" }),
 			makeConfig({ model: "anthropic/claude-opus-4-6", additionalArgs: ["--agent", "sisyphus"] }),
 			makeCtx({ taskDescription: "Build feature" }),
@@ -560,8 +560,8 @@ describe("resolveAgentCommand — resume", () => {
 	});
 
 	// ---- Unsupported agents ----
-	it("does not add resume flags for unsupported agents", () => {
-		const cmd = resolveAgentCommand(
+	it("does not add resume flags for unsupported agents", async () => {
+		const cmd = await resolveAgentCommand(
 			makeAgent({ baseCommand: "aider" }),
 			makeConfig({ model: undefined }),
 			makeCtx({ taskDescription: "Some task" }),
@@ -583,8 +583,8 @@ describe("resolveAgentCommand — empty description (scratch task) opens interac
 	// auto-ran as turn 1. With an empty prompt it must NOT be injected, so the
 	// agent opens an empty interactive window (matching Claude).
 
-	it("Codex: empty description → no positional prompt; protocol still arrives via -c", () => {
-		const cmd = resolveAgentCommand(
+	it("Codex: empty description → no positional prompt; protocol still arrives via -c", async () => {
+		const cmd = await resolveAgentCommand(
 			makeAgent({ baseCommand: "codex" }),
 			makeConfig({ model: undefined }),
 			makeCtx({ taskDescription: "" }),
@@ -599,8 +599,8 @@ describe("resolveAgentCommand — empty description (scratch task) opens interac
 		expect(cmd).toContain(`-c 'tui.theme="dracula"'`);
 	});
 
-	it("Cursor Agent: empty description → no positional prompt, no system prompt injected", () => {
-		const cmd = resolveAgentCommand(
+	it("Cursor Agent: empty description → no positional prompt, no system prompt injected", async () => {
+		const cmd = await resolveAgentCommand(
 			makeAgent({ baseCommand: "agent" }),
 			makeConfig({ model: undefined }),
 			makeCtx({ taskDescription: "" }),
@@ -610,8 +610,8 @@ describe("resolveAgentCommand — empty description (scratch task) opens interac
 		expect(cmd).not.toMatch(/ -- /);
 	});
 
-	it("OpenCode: empty description → no --prompt, no system prompt injected", () => {
-		const cmd = resolveAgentCommand(
+	it("OpenCode: empty description → no --prompt, no system prompt injected", async () => {
+		const cmd = await resolveAgentCommand(
 			makeAgent({ baseCommand: "opencode" }),
 			makeConfig({ model: undefined }),
 			makeCtx({ taskDescription: "" }),
@@ -621,8 +621,8 @@ describe("resolveAgentCommand — empty description (scratch task) opens interac
 		expect(cmd).not.toContain("--prompt");
 	});
 
-	it("Codex: non-empty description still injects description + system prompt", () => {
-		const cmd = resolveAgentCommand(
+	it("Codex: non-empty description still injects description + system prompt", async () => {
+		const cmd = await resolveAgentCommand(
 			makeAgent({ baseCommand: "codex" }),
 			makeConfig({ model: undefined }),
 			makeCtx({ taskDescription: "Fix the login bug" }),
@@ -642,8 +642,8 @@ describe("resolveAgentCommand — positional prompt separator (-- guard)", () =>
 
 	it.each(["claude", "codex", "gemini", "agent"])(
 		"%s: emits `-- <prompt>` so a '---'-prefixed description is not parsed as a flag",
-		(baseCmd) => {
-		const cmd = resolveAgentCommand(
+		async (baseCmd) => {
+		const cmd = await resolveAgentCommand(
 			makeAgent({ baseCommand: baseCmd }),
 			makeConfig({ model: undefined }),
 			makeCtx({ taskDescription: "---hello frontmatter" }),
@@ -662,8 +662,8 @@ describe("resolveAgentCommand — positional prompt separator (-- guard)", () =>
 		},
 	);
 
-	it("OpenCode: uses --prompt <value>, so no -- separator is added (value form is unambiguous)", () => {
-		const cmd = resolveAgentCommand(
+	it("OpenCode: uses --prompt <value>, so no -- separator is added (value form is unambiguous)", async () => {
+		const cmd = await resolveAgentCommand(
 			makeAgent({ baseCommand: "opencode" }),
 			makeConfig({ model: undefined }),
 			makeCtx({ taskDescription: "---hello frontmatter" }),
@@ -674,8 +674,8 @@ describe("resolveAgentCommand — positional prompt separator (-- guard)", () =>
 		expect(cmd).not.toMatch(/ -- '/);
 	});
 
-	it("Claude: -- guard is still present for plain descriptions (no regression for normal prompts)", () => {
-		const cmd = resolveAgentCommand(
+	it("Claude: -- guard is still present for plain descriptions (no regression for normal prompts)", async () => {
+		const cmd = await resolveAgentCommand(
 			makeAgent({ baseCommand: "claude" }),
 			makeConfig({ model: undefined }),
 			makeCtx({ taskDescription: "Fix the login bug" }),
@@ -684,8 +684,8 @@ describe("resolveAgentCommand — positional prompt separator (-- guard)", () =>
 		expect(cmd).toContain("-- 'Fix the login bug'");
 	});
 
-	it("does not add -- when resuming (no positional prompt is emitted on resume)", () => {
-		const cmd = resolveAgentCommand(
+	it("does not add -- when resuming (no positional prompt is emitted on resume)", async () => {
+		const cmd = await resolveAgentCommand(
 			makeAgent({ baseCommand: "claude" }),
 			makeConfig({ model: undefined }),
 			makeCtx({ taskDescription: "---hello frontmatter" }),
@@ -698,8 +698,8 @@ describe("resolveAgentCommand — positional prompt separator (-- guard)", () =>
 });
 
 describe("resolveAgentCommand — sessionId", () => {
-	it("Claude: injects --session-id for fresh launch", () => {
-		const cmd = resolveAgentCommand(
+	it("Claude: injects --session-id for fresh launch", async () => {
+		const cmd = await resolveAgentCommand(
 			makeAgent({ baseCommand: "claude" }),
 			makeConfig(),
 			makeCtx(),
@@ -710,8 +710,8 @@ describe("resolveAgentCommand — sessionId", () => {
 		expect(cmd).not.toContain("--resume");
 	});
 
-	it("Gemini: injects --session-id for fresh launch (PR #26060)", () => {
-		const cmd = resolveAgentCommand(
+	it("Gemini: injects --session-id for fresh launch (PR #26060)", async () => {
+		const cmd = await resolveAgentCommand(
 			makeAgent({ baseCommand: "gemini" }),
 			makeConfig({ model: undefined }),
 			makeCtx(),
@@ -722,8 +722,8 @@ describe("resolveAgentCommand — sessionId", () => {
 		expect(cmd).not.toContain("--resume");
 	});
 
-	it("Claude: uses --resume <id> when both resume and sessionId", () => {
-		const cmd = resolveAgentCommand(
+	it("Claude: uses --resume <id> when both resume and sessionId", async () => {
+		const cmd = await resolveAgentCommand(
 			makeAgent({ baseCommand: "claude" }),
 			makeConfig(),
 			makeCtx(),
@@ -735,8 +735,8 @@ describe("resolveAgentCommand — sessionId", () => {
 		expect(cmd).not.toContain("--continue");
 	});
 
-	it("Claude: falls back to --continue when resume without sessionId", () => {
-		const cmd = resolveAgentCommand(
+	it("Claude: falls back to --continue when resume without sessionId", async () => {
+		const cmd = await resolveAgentCommand(
 			makeAgent({ baseCommand: "claude" }),
 			makeConfig(),
 			makeCtx(),
@@ -747,8 +747,8 @@ describe("resolveAgentCommand — sessionId", () => {
 		expect(cmd).not.toContain("--session-id");
 	});
 
-	it("Gemini: uses --resume <id> when both resume and sessionId", () => {
-		const cmd = resolveAgentCommand(
+	it("Gemini: uses --resume <id> when both resume and sessionId", async () => {
+		const cmd = await resolveAgentCommand(
 			makeAgent({ baseCommand: "gemini" }),
 			makeConfig({ model: undefined }),
 			makeCtx(),
@@ -759,8 +759,8 @@ describe("resolveAgentCommand — sessionId", () => {
 		expect(cmd).not.toContain("latest");
 	});
 
-	it("Codex: uses session id in resume subcommand", () => {
-		const cmd = resolveAgentCommand(
+	it("Codex: uses session id in resume subcommand", async () => {
+		const cmd = await resolveAgentCommand(
 			makeAgent({ baseCommand: "codex" }),
 			makeConfig({ model: undefined }),
 			makeCtx(),
@@ -771,8 +771,8 @@ describe("resolveAgentCommand — sessionId", () => {
 		expect(cmd).not.toContain("--last");
 	});
 
-	it("Cursor Agent: injects --resume <id> for fresh launch (creates new thread)", () => {
-		const cmd = resolveAgentCommand(
+	it("Cursor Agent: injects --resume <id> for fresh launch (creates new thread)", async () => {
+		const cmd = await resolveAgentCommand(
 			makeAgent({ baseCommand: "agent" }),
 			makeConfig({ model: undefined }),
 			makeCtx(),
@@ -783,8 +783,8 @@ describe("resolveAgentCommand — sessionId", () => {
 		expect(cmd).not.toContain("--session-id");
 	});
 
-	it("Cursor Agent: uses --resume <id> when both resume and sessionId", () => {
-		const cmd = resolveAgentCommand(
+	it("Cursor Agent: uses --resume <id> when both resume and sessionId", async () => {
+		const cmd = await resolveAgentCommand(
 			makeAgent({ baseCommand: "agent" }),
 			makeConfig({ model: undefined }),
 			makeCtx(),
@@ -795,8 +795,8 @@ describe("resolveAgentCommand — sessionId", () => {
 		expect(cmd).not.toContain("--continue");
 	});
 
-	it("does not inject session id for unsupported agents", () => {
-		const cmd = resolveAgentCommand(
+	it("does not inject session id for unsupported agents", async () => {
+		const cmd = await resolveAgentCommand(
 			makeAgent({ baseCommand: "codex" }),
 			makeConfig({ model: undefined }),
 			makeCtx(),
@@ -957,23 +957,23 @@ describe("applyBinaryPathOverride", () => {
 // A custom executable for Claude Code must run through the very same code as
 // `claude` itself — the whole point of declaring the family.
 describe("a declared family reaches the launch command", () => {
-	it("resumes instead of re-sending the task description", () => {
+	it("resumes instead of re-sending the task description", async () => {
 		const agent = makeAgent({ baseCommand: "my-claude", agentFamily: "claude" });
-		const cmd = resolveAgentCommand(agent, makeConfig(), makeCtx(), { resume: true, sessionId: "sess-1" });
+		const cmd = await resolveAgentCommand(agent, makeConfig(), makeCtx(), { resume: true, sessionId: "sess-1" });
 		expect(cmd).toContain("my-claude --resume sess-1");
 		expect(cmd).not.toContain("Fix the login bug");
 	});
 
-	it("mints a session id on a fresh launch, so there is something to resume", () => {
+	it("mints a session id on a fresh launch, so there is something to resume", async () => {
 		const agent = makeAgent({ baseCommand: "my-claude", agentFamily: "claude" });
-		expect(resolveAgentCommand(agent, makeConfig(), makeCtx(), { sessionId: "fresh-1" }))
+		expect((await resolveAgentCommand(agent, makeConfig(), makeCtx(), { sessionId: "fresh-1" })))
 			.toContain("--session-id fresh-1");
 		expect(buildResumeCommand("my-claude", "sess-1", "claude")).toBe("my-claude --resume sess-1");
 	});
 
-	it("injects the dev3 protocol and the bypass switch, like plain claude does", () => {
+	it("injects the dev3 protocol and the bypass switch, like plain claude does", async () => {
 		const agent = makeAgent({ baseCommand: "my-claude", agentFamily: "claude" });
-		const cmd = resolveAgentCommand(agent, makeConfig(), makeCtx());
+		const cmd = await resolveAgentCommand(agent, makeConfig(), makeCtx());
 		expect(cmd).toContain("--append-system-prompt");
 		expect(cmd).toContain("--allow-dangerously-skip-permissions");
 	});
@@ -985,9 +985,9 @@ describe("a declared family reaches the launch command", () => {
 		expect(result?.model).toBe("pinned-opus");
 	});
 
-	it("leaves an undeclared custom binary on the generic path", () => {
+	it("leaves an undeclared custom binary on the generic path", async () => {
 		const agent = makeAgent({ baseCommand: "my-claude" });
-		const cmd = resolveAgentCommand(agent, makeConfig(), makeCtx(), { resume: true, sessionId: "sess-1" });
+		const cmd = await resolveAgentCommand(agent, makeConfig(), makeCtx(), { resume: true, sessionId: "sess-1" });
 		expect(cmd).not.toContain("--resume");
 		expect(cmd).toContain("Fix the login bug");
 	});
@@ -1379,9 +1379,9 @@ describe("applyModelOverride — API profile model beats the preset --model flag
 		expect(config.model).toBe("claude-opus-4-8[1m]");
 	});
 
-	it("produces a command with the overridden --model", () => {
+	it("produces a command with the overridden --model", async () => {
 		const config = applyModelOverride(makeConfig({ model: "sonnet" }), "claude", { ANTHROPIC_MODEL: "my-model" });
-		const cmd = resolveAgentCommand(makeAgent(), config, makeCtx());
+		const cmd = await resolveAgentCommand(makeAgent(), config, makeCtx());
 		expect(cmd).toContain("--model my-model");
 		expect(cmd).not.toContain("--model sonnet");
 	});

--- a/src/bun/__tests__/codex-config-windows-paths.test.ts
+++ b/src/bun/__tests__/codex-config-windows-paths.test.ts
@@ -1,10 +1,11 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi, afterEach, beforeEach } from "vitest";
 import { mkdtempSync, mkdirSync, readFileSync, writeFileSync, existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { load } from "js-toml";
 import {
 	backupUnparsableCodexConfig,
+	resetCodexVersionProbe,
 	ensureCodexConfig,
 	ensureCodexConfigFile,
 	joinLike,
@@ -144,18 +145,31 @@ describe("repairing an already-broken config", () => {
 });
 
 describe("ensureCodexConfigFile against a real home directory", () => {
-	it("writes a parsable config and repairs a broken one in place", () => {
+	beforeEach(() => resetCodexVersionProbe());
+	afterEach(() => vi.restoreAllMocks());
+	it("preserves the config when the version cannot be detected", async () => {
+		vi.spyOn(Bun, "spawn").mockImplementation(() => { throw new Error("ENOENT"); });
+		const home = mkdtempSync(join(tmpdir(), "dev3-codex-home-"));
+		mkdirSync(join(home, ".codex"), { recursive: true });
+		const configPath = join(home, ".codex", "config.toml");
+		writeFileSync(configPath, BROKEN_CONFIG);
+		await ensureCodexConfigFile(home);
+		expect(readFileSync(configPath, "utf-8")).toBe(BROKEN_CONFIG);
+		expect(existsSync(`${configPath}.dev3-backup`)).toBe(false);
+	});
+	it("writes a parsable config and repairs a broken one in place", async () => {
+		vi.spyOn(Bun, "spawn").mockReturnValue({ pid: 0, kill() {}, exited: Promise.resolve(0), stdout: new Response("codex-cli 0.154.0").body, stderr: new Response("").body } as never);
 		const home = mkdtempSync(join(tmpdir(), "dev3-codex-home-"));
 		mkdirSync(join(home, ".codex"), { recursive: true });
 		const configPath = join(home, ".codex", "config.toml");
 
-		ensureCodexConfigFile(home);
+		await ensureCodexConfigFile(home);
 		const fresh = readFileSync(configPath, "utf-8");
 		const parsed = load(fresh) as Record<string, any>;
 		expect(Object.keys(parsed.projects)).toContain(join(home, ".dev3.0", "worktrees"));
 
 		writeFileSync(configPath, BROKEN_CONFIG, "utf-8");
-		ensureCodexConfigFile(home);
+		await ensureCodexConfigFile(home);
 		const healed = readFileSync(configPath, "utf-8");
 		const healedParsed = load(healed) as Record<string, any>;
 		expect(healedParsed.model).toBe("gpt-5");

--- a/src/bun/__tests__/codex-version-probe.test.ts
+++ b/src/bun/__tests__/codex-version-probe.test.ts
@@ -1,0 +1,99 @@
+import { beforeEach, afterEach, expect, it, vi } from "vitest";
+import { detectCodexVersion, resetCodexVersionProbe, detectCodexProfileLaunchFlag, detectCodexHookTrustBypass, resetCodexHelpProbe } from "../codex-config";
+
+beforeEach(() => { resetCodexVersionProbe(); resetCodexHelpProbe(); });
+
+afterEach(() => vi.restoreAllMocks());
+
+it("keeps the event loop responsive and kills a version probe that never exits", async () => {
+	const kill = vi.fn();
+	vi.spyOn(Bun, "spawn").mockReturnValue({
+		pid: 0,
+		kill,
+		exited: new Promise(() => {}),
+		stdout: new ReadableStream(),
+		stderr: new ReadableStream(),
+	} as never);
+	const pending = detectCodexVersion();
+	expect(pending).toBeInstanceOf(Promise);
+	await new Promise<void>((resolve) => setImmediate(resolve));
+	expect(kill).not.toHaveBeenCalled();
+	expect(await pending).toBeNull();
+	expect(kill).toHaveBeenCalledWith(9);
+});
+
+it("drains both output streams while waiting for exit", async () => {
+	vi.spyOn(Bun, "spawn").mockReturnValue({
+		pid: 0,
+		kill: vi.fn(),
+		exited: Promise.resolve(0),
+		stdout: new Response("codex-cli 0.154.0\n").body,
+		stderr: new Response("diagnostic\n").body,
+	} as never);
+	expect(await detectCodexVersion()).toBe("codex-cli 0.154.0");
+});
+
+it("shares one pending probe across concurrent callers", async () => {
+	const probe = vi.spyOn(Bun, "spawn").mockReturnValue({
+		pid: 0, kill: vi.fn(), exited: Promise.resolve(0),
+		stdout: new Response("codex-cli 0.154.0").body,
+		stderr: new Response("").body,
+	} as never);
+	const first = detectCodexVersion();
+	expect(detectCodexVersion()).toBe(first);
+	await first;
+	expect(await detectCodexVersion()).toBe("codex-cli 0.154.0");
+	expect(probe).toHaveBeenCalledTimes(1);
+});
+
+it("returns unknown when the binary is missing", async () => {
+	vi.spyOn(Bun, "spawn").mockImplementation(() => { throw new Error("ENOENT"); });
+	expect(await detectCodexVersion()).toBeNull();
+});
+
+it("ignores version output from an unsuccessful process", async () => {
+	vi.spyOn(Bun, "spawn").mockReturnValue({
+		pid: 0, kill: vi.fn(), exited: Promise.resolve(1),
+		stdout: new Response("codex-cli 0.154.0").body,
+		stderr: new Response("failed").body,
+	} as never);
+	expect(await detectCodexVersion()).toBeNull();
+});
+
+
+it("shares one bounded help probe for profile and hook capabilities", async () => {
+	const kill = vi.fn();
+	const probe = vi.spyOn(Bun, "spawn").mockReturnValue({
+		pid: 0, kill, exited: new Promise(() => {}),
+		stdout: new ReadableStream(), stderr: new ReadableStream(),
+	} as never);
+	const profile = detectCodexProfileLaunchFlag();
+	const hooks = detectCodexHookTrustBypass();
+	await new Promise<void>((resolve) => setImmediate(resolve));
+	expect(kill).not.toHaveBeenCalled();
+	expect(await profile).toBe("--profile");
+	expect(await hooks).toBe(false);
+	expect(probe).toHaveBeenCalledTimes(1);
+	expect(kill).toHaveBeenCalledWith(9);
+});
+
+it("detects both capabilities from help", async () => {
+	vi.spyOn(Bun, "spawn").mockReturnValue({
+		pid: 0, kill: vi.fn(), exited: Promise.resolve(0),
+		stdout: new Response("--profile-v2 --dangerously-bypass-hook-trust").body,
+		stderr: new Response("").body,
+	} as never);
+	expect(await detectCodexProfileLaunchFlag()).toBe("--profile-v2");
+	expect(await detectCodexHookTrustBypass()).toBe(true);
+});
+
+it("bounds pipe collection even after the child exits", async () => {
+	const cancel = vi.fn();
+	const kill = vi.fn();
+	vi.spyOn(Bun, "spawn").mockReturnValue({
+		pid: 0, kill, exited: Promise.resolve(0),
+		stdout: new ReadableStream({ cancel }), stderr: new Response("").body,
+	} as never);
+	expect(await detectCodexVersion()).toBeNull();
+	expect(cancel).toHaveBeenCalled();
+});

--- a/src/bun/__tests__/tmux-pty-native-launch.test.ts
+++ b/src/bun/__tests__/tmux-pty-native-launch.test.ts
@@ -297,7 +297,7 @@ describe("Codex model/CLI version notice (issue #1667)", () => {
 
 	it("wraps the launch in the notice when the installed Codex predates the model", async () => {
 		resolveAsCodex("gpt-6-astra");
-		vi.mocked(agents.getCodexVersionCached).mockReturnValue("codex-cli 0.144.4");
+		vi.mocked(agents.getCodexVersionCached).mockResolvedValue("codex-cli 0.144.4");
 
 		await launchTaskPty(makeProject(), makeTask(), WORKTREE);
 
@@ -314,7 +314,7 @@ describe("Codex model/CLI version notice (issue #1667)", () => {
 
 	it("says nothing on a Codex new enough to run the model", async () => {
 		resolveAsCodex("gpt-6-astra");
-		vi.mocked(agents.getCodexVersionCached).mockReturnValue("codex-cli 0.153.4");
+		vi.mocked(agents.getCodexVersionCached).mockResolvedValue("codex-cli 0.153.4");
 
 		await launchTaskPty(makeProject(), makeTask(), WORKTREE);
 
@@ -323,7 +323,7 @@ describe("Codex model/CLI version notice (issue #1667)", () => {
 
 	it("says nothing when the version could not be read", async () => {
 		resolveAsCodex("gpt-6-astra");
-		vi.mocked(agents.getCodexVersionCached).mockReturnValue(null);
+		vi.mocked(agents.getCodexVersionCached).mockResolvedValue(null);
 
 		await launchTaskPty(makeProject(), makeTask(), WORKTREE);
 
@@ -334,7 +334,7 @@ describe("Codex model/CLI version notice (issue #1667)", () => {
 		// `clearAllMocks` keeps implementations, so restore the Claude default the
 		// module factory installs before asserting the negative.
 		vi.mocked(agents.resolveCommandForProject).mockResolvedValue({ command: "claude", extraEnv: {} } as never);
-		vi.mocked(agents.getCodexVersionCached).mockReturnValue("codex-cli 0.144.4");
+		vi.mocked(agents.getCodexVersionCached).mockResolvedValue("codex-cli 0.144.4");
 
 		await launchTaskPty(makeProject(), makeTask(), WORKTREE);
 

--- a/src/bun/agent-hooks.ts
+++ b/src/bun/agent-hooks.ts
@@ -12,7 +12,7 @@ import type { AgentFamily, PermissionMode, TaskStatus } from "../shared/types";
 import { createLogger } from "./logger";
 import { getAgentAdapter } from "../shared/agent-adapters/registry";
 import { writeClaudeHooks, writeCodexHooks } from "../shared/agent-hooks";
-import { CODEX_HOOK_TRUST_BYPASS_FLAG, detectCodexHookTrustBypass } from "./codex-config";
+import { CODEX_HOOK_TRUST_BYPASS_FLAG, detectCodexHookTrustBypass, resetCodexHelpProbe } from "./codex-config";
 
 export {
 	buildClaudeHooks,
@@ -25,9 +25,9 @@ export {
 
 const log = createLogger("agent-hooks");
 
-/** `codex --help` is a synchronous child spawn, and this runs on every launch. */
-let cachedHookTrustBypass: boolean | undefined;
-function getCodexHookTrustBypassCached(): boolean {
+/** Concurrent launches share the same asynchronous capability probe. */
+let cachedHookTrustBypass: Promise<boolean> | undefined;
+function getCodexHookTrustBypassCached(): Promise<boolean> {
 	if (cachedHookTrustBypass === undefined) cachedHookTrustBypass = detectCodexHookTrustBypass();
 	return cachedHookTrustBypass;
 }
@@ -35,6 +35,7 @@ function getCodexHookTrustBypassCached(): boolean {
 /** Reset the cached probe. Exposed for test isolation. */
 export function __resetCodexHookTrustBypassCache(): void {
 	cachedHookTrustBypass = undefined;
+	resetCodexHelpProbe();
 }
 
 /**
@@ -46,7 +47,7 @@ export function __resetCodexHookTrustBypassCache(): void {
  * `options.family` is which CLI this command actually is, which beats the
  * command-name guess — without it a wrapper script silently got no hooks.
  */
-export function setupAgentHooks(
+export async function setupAgentHooks(
 	worktreePath: string,
 	baseCommand: string,
 	options?: {
@@ -64,7 +65,7 @@ export function setupAgentHooks(
 			baseCommand,
 			family: options?.family ?? "auto",
 		});
-		return Promise.resolve(null);
+		return null;
 	}
 
 	if (spec.kind === "claude") {
@@ -73,18 +74,18 @@ export function setupAgentHooks(
 			worktreePath,
 			permissionMode: spec.permissionMode,
 		});
-		return Promise.resolve(null);
+		return null;
 	}
 
 	// spec.kind === "codex"
 	writeCodexHooks(worktreePath);
-	if (!getCodexHookTrustBypassCached()) {
+	if (!(await getCodexHookTrustBypassCached())) {
 		// Worth a line: the definitions are in place, Codex reports them untrusted,
 		// and an untrusted hook is skipped in silence — so the board simply stops
 		// following this task and nothing else would say why.
 		log.warn("Codex cannot bypass hook trust; status hooks will not fire", { worktreePath });
-		return Promise.resolve(null);
+		return null;
 	}
 	log.info("Codex status hooks active (declared in config.toml)", { worktreePath });
-	return Promise.resolve(CODEX_HOOK_TRUST_BYPASS_FLAG);
+	return CODEX_HOOK_TRUST_BYPASS_FLAG;
 }

--- a/src/bun/agent-skills.ts
+++ b/src/bun/agent-skills.ts
@@ -1549,7 +1549,7 @@ export interface InstallAgentSkillsOptions {
 	lowBattery?: boolean;
 }
 
-export function installAgentSkills(options: InstallAgentSkillsOptions = {}): void {
+export async function installAgentSkills(options: InstallAgentSkillsOptions = {}): Promise<void> {
 	const home = homedir();
 
 	// Install Claude-specific skill (with command injection). SKILL.md is short
@@ -1728,6 +1728,6 @@ export function installAgentSkills(options: InstallAgentSkillsOptions = {}): voi
 	installAgentsMd(options.lowBattery === true);
 	ensureClaudeSettings(home);
 	if (options.configureCodex !== false) {
-		ensureCodexConfigFile(home);
+		await ensureCodexConfigFile(home);
 	}
 }

--- a/src/bun/agents.ts
+++ b/src/bun/agents.ts
@@ -7,7 +7,7 @@ import { DEFAULT_AGENTS, DEPRECATED_DEFAULT_CONFIG_REMAP } from "../shared/types
 export { skillInvocationPrefix } from "../shared/types";
 import { buildProviderEnv, getProviderDefinition, providerOmitsModelFlag, providerPinnedModel } from "../shared/llm-provider";
 import { createLogger } from "./logger";
-import { backupUnparsableCodexConfig, joinLike as joinLikeHome, detectCodexProfileLaunchFlag, detectCodexVersion, ensureCodexConfig, ensureCodexProfileFiles, getCodexSyntaxForVersion, type CodexProfileLaunchFlag } from "./codex-config";
+import { backupUnparsableCodexConfig, joinLike as joinLikeHome, detectCodexProfileLaunchFlag, detectCodexVersion, resetCodexVersionProbe, resetCodexHelpProbe, ensureCodexConfig, ensureCodexProfileFiles, getCodexSyntaxForVersion, type CodexProfileLaunchFlag } from "./codex-config";
 import { agentBinaryPathOverride } from "./executable";
 import { DEV3_HOME } from "./paths";
 // Writer and pruner share one path constant: whatever registers an entry must
@@ -357,7 +357,7 @@ export function isClaudeCommand(baseCmd: string, family?: AgentFamily): boolean 
 }
 
 let codexProfileLaunchFlagOverride: CodexProfileLaunchFlag | null = null;
-let cachedCodexProfileLaunchFlag: CodexProfileLaunchFlag | undefined;
+let cachedCodexProfileLaunchFlag: Promise<CodexProfileLaunchFlag> | undefined;
 
 /**
  * Test-only override for codex profile launch-flag detection.
@@ -366,6 +366,7 @@ let cachedCodexProfileLaunchFlag: CodexProfileLaunchFlag | undefined;
 export function __setCodexProfileV2Override(value: boolean | null): void {
 	codexProfileLaunchFlagOverride = value === null ? null : value ? "--profile-v2" : "--profile";
 	cachedCodexProfileLaunchFlag = undefined;
+	resetCodexHelpProbe();
 }
 
 /**
@@ -375,7 +376,7 @@ export function __setCodexProfileV2Override(value: boolean | null): void {
  * Feature-detected from `codex --help` and cached for the process lifetime —
  * version numbers do not map reliably to the rename. See issue #611.
  */
-function getCodexProfileLaunchFlag(): CodexProfileLaunchFlag {
+async function getCodexProfileLaunchFlag(): Promise<CodexProfileLaunchFlag> {
 	if (codexProfileLaunchFlagOverride !== null) return codexProfileLaunchFlagOverride;
 	if (cachedCodexProfileLaunchFlag === undefined) {
 		cachedCodexProfileLaunchFlag = detectCodexProfileLaunchFlag();
@@ -383,33 +384,25 @@ function getCodexProfileLaunchFlag(): CodexProfileLaunchFlag {
 	return cachedCodexProfileLaunchFlag;
 }
 
-/**
- * `codex --version`, cached for the process lifetime. The probe is a
- * synchronous child spawn — uncached it ran on EVERY task launch inside
- * ensureCodexTrust, blocking the main loop each time.
- */
-let cachedCodexVersion: string | null | undefined;
-export function getCodexVersionCached(): string | null {
-	if (cachedCodexVersion === undefined) {
-		cachedCodexVersion = detectCodexVersion();
-	}
-	return cachedCodexVersion;
+/** Startup and task restoration share one bounded, asynchronous version probe. */
+export function getCodexVersionCached(): Promise<string | null> {
+	return detectCodexVersion();
 }
 
-/** Reset the cached codex version. Exposed for test isolation. */
+/** Reset the shared probe for test isolation. */
 export function __resetCodexVersionCache(): void {
-	cachedCodexVersion = undefined;
+	resetCodexVersionProbe();
 }
 
 /** Resolve the impure Codex launch runtime (active UI theme → profile/theme,
  *  and the feature-detected profile launch flag) into pure data the CodexAdapter
  *  consumes. Only called for Codex launches so non-Codex agents never trigger the
  *  `codex --help` probe. */
-function codexLaunchRuntime(): CodexLaunchRuntime {
+async function codexLaunchRuntime(): Promise<CodexLaunchRuntime> {
 	return {
 		themedProfile: getCodexProfileForCurrentUiTheme(),
 		theme: getCodexThemeForCurrentUiTheme(),
-		profileLaunchFlag: getCodexProfileLaunchFlag(),
+		profileLaunchFlag: await getCodexProfileLaunchFlag(),
 	};
 }
 
@@ -478,12 +471,12 @@ export function supportsPreAssignedSessionId(baseCmd: string, family?: AgentFami
  * impure inputs the pure adapter needs — the third-party-provider skip-model
  * rule and the Codex theme/profile runtime — and threads them in.
  */
-export function resolveAgentCommand(
+export async function resolveAgentCommand(
 	agent: CodingAgent,
 	config: AgentConfiguration | undefined,
 	ctx: TemplateContext,
 	options?: CommandOptions,
-): string {
+): Promise<string> {
 	const baseCmd = config?.baseCommandOverride || agent.baseCommand;
 	const adapter = getAgentAdapter(baseCmd, agent.agentFamily);
 
@@ -500,7 +493,7 @@ export function resolveAgentCommand(
 		providerArgs: launchExtraArgs(options),
 		// Codex-only: resolve the theme/profile runtime (impure) here so the pure
 		// adapter stays pure. Non-Codex agents skip it (avoids the codex --help probe).
-		codex: adapter.command === "codex" ? codexLaunchRuntime() : undefined,
+		codex: adapter.command === "codex" ? await codexLaunchRuntime() : undefined,
 		// The protocol reaches Claude as a file on every platform: Windows cannot
 		// carry it on the command line, and POSIX argv is what `pkill -f` matches
 		// against. Resolved here because writing one is impure and adapters are not.
@@ -825,7 +818,7 @@ export async function resolveCommandForAgent(
 	await applyCodexAccountEnv(baseCmd, extraEnv, options?.accountId, agentWithPath.agentFamily);
 	const routed = await applyModelRoleLaunch(baseCmd, config, extraEnv, providerOpts, agentWithPath.agentFamily);
 	const launchConfig = resolveLaunchConfig(routed.config, agentWithPath, baseCmd, extraEnv, routed.pinnedModel);
-	const command = resolveAgentCommand(agentWithPath, launchConfig, ctx, routed.options);
+	const command = await resolveAgentCommand(agentWithPath, launchConfig, ctx, routed.options);
 	// `agent` stays the stored record — callers derive the base command from it,
 	// and swapping in the override path there would change what they persist.
 	// The family rides alongside instead: a path override can pin one the stored
@@ -956,7 +949,7 @@ export async function resolveCommandForProject(
 		await applyCodexAccountEnv(baseCmd, extraEnv, options?.accountId, agentWithPath.agentFamily);
 		const routed = await applyModelRoleLaunch(baseCmd, config, extraEnv, providerOpts, agentWithPath.agentFamily);
 		const launchConfig = resolveLaunchConfig(routed.config, agentWithPath, baseCmd, extraEnv, routed.pinnedModel);
-		const command = resolveAgentCommand(agentWithPath, launchConfig, ctx, routed.options);
+		const command = await resolveAgentCommand(agentWithPath, launchConfig, ctx, routed.options);
 		return {
 			command,
 			agent,
@@ -1051,6 +1044,9 @@ export async function ensureCodexTrust(dirPath: string): Promise<void> {
 		const worktreesPath = joinLikeHome(home, ".dev3.0", "worktrees");
 		const socketsPath = joinLikeHome(home, ".dev3.0", "sockets");
 
+		const codexVersion = await getCodexVersionCached();
+		if (codexVersion === null) return;
+
 		let content: string | null = null;
 		try {
 			content = readFileSync(CODEX_CONFIG, "utf-8");
@@ -1060,7 +1056,6 @@ export async function ensureCodexTrust(dirPath: string): Promise<void> {
 
 		if (content != null) backupUnparsableCodexConfig(CODEX_CONFIG, content);
 
-		const codexVersion = getCodexVersionCached();
 		const updated = ensureCodexConfig(content, worktreesPath, socketsPath, [worktreesPath, resolved], {
 			codexVersion,
 		});

--- a/src/bun/codex-config.ts
+++ b/src/bun/codex-config.ts
@@ -5,7 +5,7 @@ import { buildCodexHooks, CODEX_STATUS_HOOK_EVENTS, mentionsDev3Cli } from "../s
 import { type CliVersion, isCliVersionAtLeast, parseCliVersion } from "../shared/agent-model-cli-requirements";
 import type { HookCliDialect } from "../shared/dev3-cli-path";
 import { createLogger } from "./logger";
-import { spawnSync } from "./spawn";
+import { spawn } from "./spawn";
 import { DEV3_CODEX_DARK_PROFILE, DEV3_CODEX_LIGHT_PROFILE } from "./theme-state";
 
 const log = createLogger("codex-config");
@@ -657,15 +657,8 @@ export function pickCodexProfileLaunchFlag(helpText: string): CodexProfileLaunch
  * Falls back to `--profile` (the modern, post-rename flag) when help can't be
  * read — it is the safe default since `--profile-v2` is the flag that crashes.
  */
-export function detectCodexProfileLaunchFlag(): CodexProfileLaunchFlag {
-	try {
-		const result = spawnSync(["codex", "--help"], { stdout: "pipe", stderr: "pipe" });
-		const stdout = result.stdout ? new TextDecoder().decode(result.stdout) : "";
-		const stderr = result.stderr ? new TextDecoder().decode(result.stderr) : "";
-		return pickCodexProfileLaunchFlag(`${stdout}\n${stderr}`);
-	} catch {
-		return "--profile";
-	}
+export async function detectCodexProfileLaunchFlag(): Promise<CodexProfileLaunchFlag> {
+	return pickCodexProfileLaunchFlag(await detectCodexHelp() ?? "");
 }
 
 /** The flag that runs enabled hooks without persisted per-hook trust. */
@@ -685,27 +678,65 @@ export function supportsCodexHookTrustBypass(helpText: string): boolean {
 }
 
 /** Probe the installed Codex's `--help`. Unreadable help means "assume not". */
-export function detectCodexHookTrustBypass(): boolean {
-	try {
-		const result = spawnSync(["codex", "--help"], { stdout: "pipe", stderr: "pipe" });
-		const stdout = result.stdout ? new TextDecoder().decode(result.stdout) : "";
-		const stderr = result.stderr ? new TextDecoder().decode(result.stderr) : "";
-		return supportsCodexHookTrustBypass(`${stdout}\n${stderr}`);
-	} catch {
-		return false;
-	}
+export async function detectCodexHookTrustBypass(): Promise<boolean> {
+	return supportsCodexHookTrustBypass(await detectCodexHelp() ?? "");
 }
 
-export function detectCodexVersion(): string | null {
-	try {
-		const result = spawnSync(["codex", "--version"], { stdout: "pipe", stderr: "pipe" });
-		if (result.exitCode !== 0) return null;
+let codexHelpProbe: Promise<string | null> | undefined;
 
-		const stdout = result.stdout ? new TextDecoder().decode(result.stdout) : "";
-		const stderr = result.stderr ? new TextDecoder().decode(result.stderr) : "";
-		return stdout.trim() || stderr.trim() || null;
-	} catch {
+function detectCodexHelp(): Promise<string | null> {
+	return codexHelpProbe ??= probeCodex("--help");
+}
+
+export function resetCodexHelpProbe(): void {
+	codexHelpProbe = undefined;
+}
+
+let codexVersionProbe: Promise<string | null> | undefined;
+
+export function resetCodexVersionProbe(): void {
+	codexVersionProbe = undefined;
+}
+
+export function detectCodexVersion(): Promise<string | null> {
+	return codexVersionProbe ??= probeCodex("--version");
+}
+
+async function probeCodex(flag: "--version" | "--help"): Promise<string | null> {
+	let timer: ReturnType<typeof setTimeout> | undefined;
+	let proc: ReturnType<typeof spawn> | undefined;
+	const readers: ReadableStreamDefaultReader<Uint8Array>[] = [];
+	try {
+		proc = spawn(["codex", flag], { stdin: "ignore", stdout: "pipe", stderr: "pipe" });
+		const read = async (stream: ReadableStream<Uint8Array> | undefined): Promise<string> => {
+			if (!stream) return "";
+			const reader = stream.getReader();
+			readers.push(reader);
+			const decoder = new TextDecoder();
+			let output = "";
+			for (;;) {
+				const { done, value } = await reader.read();
+				if (done) return output + decoder.decode();
+				output += decoder.decode(value, { stream: true });
+				if (output.length > 65_536) throw new Error("Codex probe output exceeded limit");
+			}
+		};
+		const result = await Promise.race([
+			Promise.all([proc.exited, read(proc.stdout), read(proc.stderr)]),
+			new Promise<never>((_, reject) => {
+				timer = setTimeout(() => reject(new Error("Codex probe timed out after 2000ms")), 2_000);
+			}),
+		]);
+		const [exitCode, stdout, stderr] = result;
+		if (exitCode !== 0) return null;
+		return flag === "--help" ? `${stdout}\n${stderr}`.trim() || null : stdout.trim() || stderr.trim() || null;
+	} catch (err) {
+		try { proc?.kill(9); } catch { /* The child may already have exited. */ }
+		log.warn("Codex probe failed", { flag, error: String(err) });
 		return null;
+	} finally {
+		if (timer) clearTimeout(timer);
+		for (const reader of readers) void reader.cancel().catch(() => {});
 	}
 }
 
@@ -1526,11 +1557,12 @@ export function ensureCodexProfileFile(
  * Called after the app resolves the user's shell PATH during startup, and by
  * installAgentSkills() when the skills installer is invoked directly.
  */
-export function ensureCodexConfigFile(homePath: string): void {
+export async function ensureCodexConfigFile(homePath: string): Promise<void> {
 	const configPath = join(homePath, ".codex", "config.toml");
 	const worktreesPath = joinLike(homePath, ".dev3.0", "worktrees");
 	const socketsPath = joinLike(homePath, ".dev3.0", "sockets");
-	const codexVersion = detectCodexVersion();
+	const codexVersion = await detectCodexVersion();
+	if (codexVersion === null) return;
 	const syntax = getCodexSyntaxForVersion(codexVersion);
 
 	try {

--- a/src/bun/index.ts
+++ b/src/bun/index.ts
@@ -179,7 +179,7 @@ log.info("Log files", { dir: getLogPath() });
 
 	// Install dev3 skill into all supported AI agent directories (~/.claude, ~/.codex, etc.).
 	// Overwritten on every start to match the running app version (same pattern as CLI binary).
-	installAgentSkills({ configureCodex: false, lowBattery: loadSettingsSync().lowBatteryEnabled });
+	await installAgentSkills({ configureCodex: false, lowBattery: loadSettingsSync().lowBatteryEnabled });
 
 	// Append ~/.dev3.0/bin to the user's shell rc files (idempotent).
 	// This makes `dev3` available in all terminals, not just worktree tmux
@@ -250,7 +250,7 @@ if (shellEnv.path) {
 
 // Codex profile migration depends on `codex --version`. Run it only after the
 // user's shell PATH is available; the app bundle starts with a minimal PATH.
-ensureCodexConfigFile(homedir());
+await ensureCodexConfigFile(homedir());
 
 // Windows has no other entry point: nothing but the unpublished Setup extractor
 // ever writes a .lnk, so without this a zip user cannot start dev3 after a reboot.

--- a/src/bun/rpc-handlers/settings-config.ts
+++ b/src/bun/rpc-handlers/settings-config.ts
@@ -274,7 +274,7 @@ async function saveGlobalSettings(params: GlobalSettings): Promise<void> {
 			// line inside dev3's managed block in ~/.agents/AGENTS.md. An explicit
 			// false here is a real uninstall, which is why the flag is passed, not
 			// left undefined.
-			installAgentSkills({ lowBattery: next.lowBatteryEnabled === true });
+			await installAgentSkills({ lowBattery: next.lowBatteryEnabled === true });
 		} catch (err) {
 			log.warn("Failed to apply the low-battery toggle (non-fatal)", { error: String(err) });
 		}

--- a/src/bun/rpc-handlers/tmux-pty.ts
+++ b/src/bun/rpc-handlers/tmux-pty.ts
@@ -676,7 +676,7 @@ async function applyModelVersionNotice(
 	opts: { baseCmd: string; family: AgentFamily | undefined; launchModel: string | undefined; userShell?: string },
 ): Promise<string> {
 	if (agentKey(opts.baseCmd, opts.family) !== "codex") return command;
-	const support = evaluateCodexModelSupport(opts.launchModel, agents.getCodexVersionCached());
+	const support = evaluateCodexModelSupport(opts.launchModel, await agents.getCodexVersionCached());
 	if (support.status !== "too-old") return command;
 
 	log.warn("Codex CLI predates the launch model", {

--- a/src/cli/commands/install-skills.ts
+++ b/src/cli/commands/install-skills.ts
@@ -8,7 +8,7 @@ export async function handleInstallSkills(): Promise<void> {
 	// Re-installing must not turn on a feature the user never asked for, nor
 	// resurrect one they switched off in Settings.
 	const lowBattery = loadSettingsSync().lowBatteryEnabled;
-	installAgentSkills({ lowBattery });
+	await installAgentSkills({ lowBattery });
 
 	process.stdout.write("Installed agent skills:\n");
 	for (const rel of MANAGED_SKILL_FILES) {

--- a/src/mainview/__tests__/agents.test.ts
+++ b/src/mainview/__tests__/agents.test.ts
@@ -731,95 +731,95 @@ describe("resolveAgentCommand", () => {
 	};
 	const ctx = makeCtx();
 
-	it("builds basic command with no config", () => {
-		const cmd = resolveAgentCommand(agent, undefined, ctx);
+	it("builds basic command with no config", async () => {
+		const cmd = await resolveAgentCommand(agent, undefined, ctx);
 		expect(cmd).toContain("claude");
 		expect(cmd).toContain("'Fix the login bug'");
 	});
 
-	it("adds --model flag from config", () => {
+	it("adds --model flag from config", async () => {
 		const config: AgentConfiguration = { id: "c1", name: "Test", model: "opus" };
-		const cmd = resolveAgentCommand(agent, config, ctx);
+		const cmd = await resolveAgentCommand(agent, config, ctx);
 		expect(cmd).toContain("--model opus");
 	});
 
-	it("adds --permission-mode flag", () => {
+	it("adds --permission-mode flag", async () => {
 		const config: AgentConfiguration = {
 			id: "c1",
 			name: "Test",
 			permissionMode: "plan",
 		};
-		const cmd = resolveAgentCommand(agent, config, ctx);
+		const cmd = await resolveAgentCommand(agent, config, ctx);
 		expect(cmd).toContain("--permission-mode plan");
 	});
 
-	it("does not add --permission-mode when set to 'default'", () => {
+	it("does not add --permission-mode when set to 'default'", async () => {
 		const config: AgentConfiguration = {
 			id: "c1",
 			name: "Test",
 			permissionMode: "default",
 		};
-		const cmd = resolveAgentCommand(agent, config, ctx);
+		const cmd = await resolveAgentCommand(agent, config, ctx);
 		expect(cmd).not.toContain("--permission-mode");
 	});
 
-	it("adds --effort flag", () => {
+	it("adds --effort flag", async () => {
 		const config: AgentConfiguration = { id: "c1", name: "Test", effort: "high" };
-		const cmd = resolveAgentCommand(agent, config, ctx);
+		const cmd = await resolveAgentCommand(agent, config, ctx);
 		expect(cmd).toContain("--effort high");
 	});
 
-	it("adds --max-budget-usd flag", () => {
+	it("adds --max-budget-usd flag", async () => {
 		const config: AgentConfiguration = {
 			id: "c1",
 			name: "Test",
 			maxBudgetUsd: 5.5,
 		};
-		const cmd = resolveAgentCommand(agent, config, ctx);
+		const cmd = await resolveAgentCommand(agent, config, ctx);
 		expect(cmd).toContain("--max-budget-usd 5.5");
 	});
 
-	it("does not add --max-budget-usd when 0", () => {
+	it("does not add --max-budget-usd when 0", async () => {
 		const config: AgentConfiguration = {
 			id: "c1",
 			name: "Test",
 			maxBudgetUsd: 0,
 		};
-		const cmd = resolveAgentCommand(agent, config, ctx);
+		const cmd = await resolveAgentCommand(agent, config, ctx);
 		expect(cmd).not.toContain("--max-budget-usd");
 	});
 
-	it("appends additionalArgs", () => {
+	it("appends additionalArgs", async () => {
 		const config: AgentConfiguration = {
 			id: "c1",
 			name: "Test",
 			additionalArgs: ["--verbose", "--debug"],
 		};
-		const cmd = resolveAgentCommand(agent, config, ctx);
+		const cmd = await resolveAgentCommand(agent, config, ctx);
 		expect(cmd).toContain("--verbose --debug");
 	});
 
-	it("appends interpolated appendPrompt to task description", () => {
+	it("appends interpolated appendPrompt to task description", async () => {
 		const config: AgentConfiguration = {
 			id: "c1",
 			name: "Test",
 			appendPrompt: "Project: {{PROJECT_NAME}}",
 		};
-		const cmd = resolveAgentCommand(agent, config, ctx);
+		const cmd = await resolveAgentCommand(agent, config, ctx);
 		expect(cmd).toContain("Fix the login bug\n\nProject: my-project");
 	});
 
-	it("uses baseCommandOverride when set", () => {
+	it("uses baseCommandOverride when set", async () => {
 		const config: AgentConfiguration = {
 			id: "c1",
 			name: "Test",
 			baseCommandOverride: "my-claude-wrapper",
 		};
-		const cmd = resolveAgentCommand(agent, config, ctx);
+		const cmd = await resolveAgentCommand(agent, config, ctx);
 		expect(cmd).toMatch(/^my-claude-wrapper /);
 	});
 
-	it("builds full command with all config fields", () => {
+	it("builds full command with all config fields", async () => {
 		const config: AgentConfiguration = {
 			id: "c1",
 			name: "Full",
@@ -831,7 +831,7 @@ describe("resolveAgentCommand", () => {
 			appendPrompt: "Extra: {{TASK_TITLE}}",
 			baseCommandOverride: "my-claude",
 		};
-		const cmd = resolveAgentCommand(agent, config, ctx);
+		const cmd = await resolveAgentCommand(agent, config, ctx);
 
 		expect(cmd).toMatch(/^my-claude /);
 		expect(cmd).toContain("--model opus");
@@ -842,19 +842,19 @@ describe("resolveAgentCommand", () => {
 		expect(cmd).toContain("Extra: Fix bug");
 	});
 
-	it("handles empty task description with appendPrompt", () => {
+	it("handles empty task description with appendPrompt", async () => {
 		const config: AgentConfiguration = {
 			id: "c1",
 			name: "Test",
 			appendPrompt: "Do work on {{PROJECT_NAME}}",
 		};
 		const emptyCtx = makeCtx({ taskDescription: "" });
-		const cmd = resolveAgentCommand(agent, config, emptyCtx);
+		const cmd = await resolveAgentCommand(agent, config, emptyCtx);
 		expect(cmd).toContain("Do work on my-project");
 	});
 
-	it("hands claude its protocol body as a file for the claude base command", () => {
-		const cmd = resolveAgentCommand(agent, undefined, ctx);
+	it("hands claude its protocol body as a file for the claude base command", async () => {
+		const cmd = await resolveAgentCommand(agent, undefined, ctx);
 		expect(cmd).toContain("--append-system-prompt-file");
 		expect(cmd).toContain("agent-prompts/claude.md");
 		// The body itself stays out of argv, where pkill -f would match it (#1734).
@@ -864,24 +864,24 @@ describe("resolveAgentCommand", () => {
 		expect(readFileSync(promptFile, "utf-8")).toContain("dev-3.0");
 	});
 
-	it("does not inject --append-system-prompt for non-claude agents", () => {
+	it("does not inject --append-system-prompt for non-claude agents", async () => {
 		const nonClaude: CodingAgent = {
 			id: "a2",
 			name: "Codex",
 			baseCommand: "codex",
 			configurations: [],
 		};
-		const cmd = resolveAgentCommand(nonClaude, undefined, ctx);
+		const cmd = await resolveAgentCommand(nonClaude, undefined, ctx);
 		expect(cmd).not.toContain("--append-system-prompt");
 	});
 
-	it("does not inject --append-system-prompt when baseCommandOverride is non-claude", () => {
+	it("does not inject --append-system-prompt when baseCommandOverride is non-claude", async () => {
 		const config: AgentConfiguration = {
 			id: "c1",
 			name: "Test",
 			baseCommandOverride: "my-wrapper",
 		};
-		const cmd = resolveAgentCommand(agent, config, ctx);
+		const cmd = await resolveAgentCommand(agent, config, ctx);
 		expect(cmd).not.toContain("--append-system-prompt");
 	});
 
@@ -896,90 +896,90 @@ describe("resolveAgentCommand", () => {
 			configurations: [],
 		};
 
-		it("escapes single quotes in task description", () => {
+		it("escapes single quotes in task description", async () => {
 			const c = makeCtx({ taskDescription: "Fix it's broken flow" });
-			const cmd = resolveAgentCommand(simpleAgent, undefined, c);
+			const cmd = await resolveAgentCommand(simpleAgent, undefined, c);
 			expect(cmd).toBe("bash-agent -- 'Fix it'\\''s broken flow'");
 		});
 
-		it("preserves double quotes in task description (safe inside single quotes)", () => {
+		it("preserves double quotes in task description (safe inside single quotes)", async () => {
 			const c = makeCtx({ taskDescription: 'Fix the "login" page' });
-			const cmd = resolveAgentCommand(simpleAgent, undefined, c);
+			const cmd = await resolveAgentCommand(simpleAgent, undefined, c);
 			expect(cmd).toBe("bash-agent -- 'Fix the \"login\" page'");
 		});
 
-		it("preserves dollar signs in task description", () => {
+		it("preserves dollar signs in task description", async () => {
 			const c = makeCtx({ taskDescription: "Check $HOME and $PATH vars" });
-			const cmd = resolveAgentCommand(simpleAgent, undefined, c);
+			const cmd = await resolveAgentCommand(simpleAgent, undefined, c);
 			expect(cmd).toBe("bash-agent -- 'Check $HOME and $PATH vars'");
 		});
 
-		it("preserves backticks in task description", () => {
+		it("preserves backticks in task description", async () => {
 			const c = makeCtx({ taskDescription: "Run `whoami` and check" });
-			const cmd = resolveAgentCommand(simpleAgent, undefined, c);
+			const cmd = await resolveAgentCommand(simpleAgent, undefined, c);
 			expect(cmd).toBe("bash-agent -- 'Run `whoami` and check'");
 		});
 
-		it("preserves command substitution syntax in task description", () => {
+		it("preserves command substitution syntax in task description", async () => {
 			const c = makeCtx({ taskDescription: "Value is $(cat /etc/passwd)" });
-			const cmd = resolveAgentCommand(simpleAgent, undefined, c);
+			const cmd = await resolveAgentCommand(simpleAgent, undefined, c);
 			expect(cmd).toBe("bash-agent -- 'Value is $(cat /etc/passwd)'");
 		});
 
-		it("preserves semicolons and pipes in task description", () => {
+		it("preserves semicolons and pipes in task description", async () => {
 			const c = makeCtx({ taskDescription: "step1; step2 | step3" });
-			const cmd = resolveAgentCommand(simpleAgent, undefined, c);
+			const cmd = await resolveAgentCommand(simpleAgent, undefined, c);
 			expect(cmd).toBe("bash-agent -- 'step1; step2 | step3'");
 		});
 
-		it("preserves backslashes in task description", () => {
+		it("preserves backslashes in task description", async () => {
 			const c = makeCtx({ taskDescription: "path\\to\\file" });
-			const cmd = resolveAgentCommand(simpleAgent, undefined, c);
+			const cmd = await resolveAgentCommand(simpleAgent, undefined, c);
 			expect(cmd).toBe("bash-agent -- 'path\\to\\file'");
 		});
 
-		it("preserves newlines in task description", () => {
+		it("preserves newlines in task description", async () => {
 			const c = makeCtx({ taskDescription: "line1\nline2\nline3" });
-			const cmd = resolveAgentCommand(simpleAgent, undefined, c);
+			const cmd = await resolveAgentCommand(simpleAgent, undefined, c);
 			expect(cmd).toBe("bash-agent -- 'line1\nline2\nline3'");
 		});
 
-		it("handles injection attempt via single-quote breakout", () => {
+		it("handles injection attempt via single-quote breakout", async () => {
 			const c = makeCtx({ taskDescription: "'; rm -rf / #" });
-			const cmd = resolveAgentCommand(simpleAgent, undefined, c);
+			const cmd = await resolveAgentCommand(simpleAgent, undefined, c);
 			expect(cmd).toBe("bash-agent -- ''\\''; rm -rf / #'");
 		});
 
-		it("handles complex real-world task with mixed special chars", () => {
+		it("handles complex real-world task with mixed special chars", async () => {
 			const desc = "Fix the \"login\" bug (it's broken); check $PATH & `env` | grep HOME";
 			const c = makeCtx({ taskDescription: desc });
-			const cmd = resolveAgentCommand(simpleAgent, undefined, c);
+			const cmd = await resolveAgentCommand(simpleAgent, undefined, c);
 			expect(cmd).toBe(
 				"bash-agent -- 'Fix the \"login\" bug (it'\\''s broken); check $PATH & `env` | grep HOME'",
 			);
 		});
 
-		it("handles unicode and emoji in task description", () => {
+		it("handles unicode and emoji in task description", async () => {
 			const c = makeCtx({ taskDescription: "Исправь баг 🐛 в компоненте" });
-			const cmd = resolveAgentCommand(simpleAgent, undefined, c);
+			const cmd = await resolveAgentCommand(simpleAgent, undefined, c);
 			expect(cmd).toBe("bash-agent -- 'Исправь баг 🐛 в компоненте'");
 		});
 
-		it("escapes task description with only single quotes", () => {
+		it("escapes task description with only single quotes", async () => {
 			const c = makeCtx({ taskDescription: "'''" });
-			const cmd = resolveAgentCommand(simpleAgent, undefined, c);
+			const cmd = await resolveAgentCommand(simpleAgent, undefined, c);
 			expect(cmd).toBe("bash-agent -- ''\\'''\\'''\\'''");
 		});
 
-		it("preserves redirect operators in task description", () => {
+		it("preserves redirect operators in task description", async () => {
 			const c = makeCtx({ taskDescription: "output > /dev/null 2>&1" });
-			const cmd = resolveAgentCommand(simpleAgent, undefined, c);
+			const cmd = await resolveAgentCommand(simpleAgent, undefined, c);
 			expect(cmd).toBe("bash-agent -- 'output > /dev/null 2>&1'");
 		});
 
-		it("preserves glob patterns in task description", () => {
+		it("preserves glob patterns in task description", async () => {
 			const c = makeCtx({ taskDescription: "Fix *.ts files in src/**/" });
-			const cmd = resolveAgentCommand(simpleAgent, undefined, c);
+			const cmd = await resolveAgentCommand(simpleAgent, undefined, c);
 			expect(cmd).toBe("bash-agent -- 'Fix *.ts files in src/**/'");
 		});
 	});
@@ -994,7 +994,7 @@ describe("resolveAgentCommand", () => {
 			configurations: [],
 		};
 
-		it("escapes task title with single quotes when interpolated via template", () => {
+		it("escapes task title with single quotes when interpolated via template", async () => {
 			const config: AgentConfiguration = {
 				id: "c1",
 				name: "Test",
@@ -1004,12 +1004,12 @@ describe("resolveAgentCommand", () => {
 				taskTitle: "Fix it's problem",
 				taskDescription: "",
 			});
-			const cmd = resolveAgentCommand(simpleAgent, config, c);
+			const cmd = await resolveAgentCommand(simpleAgent, config, c);
 			// The interpolated prompt "Title: Fix it's problem" gets shellEscape'd
 			expect(cmd).toBe("bash-agent -- 'Title: Fix it'\\''s problem'");
 		});
 
-		it("escapes task title with dollar signs when interpolated via template", () => {
+		it("escapes task title with dollar signs when interpolated via template", async () => {
 			const config: AgentConfiguration = {
 				id: "c1",
 				name: "Test",
@@ -1019,11 +1019,11 @@ describe("resolveAgentCommand", () => {
 				taskTitle: "Check $HOME path",
 				taskDescription: "",
 			});
-			const cmd = resolveAgentCommand(simpleAgent, config, c);
+			const cmd = await resolveAgentCommand(simpleAgent, config, c);
 			expect(cmd).toBe("bash-agent -- 'Work on: Check $HOME path'");
 		});
 
-		it("escapes combined description + appendPrompt with special chars", () => {
+		it("escapes combined description + appendPrompt with special chars", async () => {
 			const config: AgentConfiguration = {
 				id: "c1",
 				name: "Test",
@@ -1033,7 +1033,7 @@ describe("resolveAgentCommand", () => {
 				taskTitle: "Fix 'auth' bug",
 				taskDescription: "The $user can't login",
 			});
-			const cmd = resolveAgentCommand(simpleAgent, config, c);
+			const cmd = await resolveAgentCommand(simpleAgent, config, c);
 			// Description + \n\n + interpolated appendPrompt, all shellEscape'd
 			expect(cmd).toBe(
 				"bash-agent -- 'The $user can'\\''t login\n\nTitle: Fix '\\''auth'\\'' bug'",


### PR DESCRIPTION
A stuck Codex version or help command could block the desktop backend indefinitely during startup or terminal restoration, leaving the UI on Connecting. Run these probes asynchronously with a two-second deadline covering process exit and both output streams, share pending results, and kill/cancel stalled probes. If the version is unavailable, preserve existing Codex configuration.

Propagate async completion through command assembly, hook setup, and skill installation. Read trust configuration only after awaiting the probe so concurrent launches cannot overwrite each other's entries.

Validation: regression coverage for nonresponsive children, pipes held open after exit, concurrent callers, missing/failed binaries, capability detection, and config preservation. A real Bun replay returns after 2,004 ms with 95 heartbeat ticks, versus zero heartbeat ticks before the fix. The original incident was localized from logs; its exact blocking instruction was not sampled. Investigation and adjacent execution audit are in docs/investigations/2026-09-12-ui-connecting.md.

---

🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=bd6eccaf-4190-4382-9014-1e47e994789c) · `dev3://task/bd6eccaf-4190-4382-9014-1e47e994789c` _(dev3 added this footer — turn it off in Settings → Tasks.)_