### PR TITLE
Refuse tasks from another project in the board task store

### DIFF
--- a/change-logs/2026/09/12/fix-cross-project-card-leak.md
+++ b/change-logs/2026/09/12/fix-cross-project-card-leak.md
@@ -1,0 +1,1 @@
+Creating a task into another project from the New Task dialog and launching it immediately no longer drops its card onto the board you were looking at. The task store now refuses any task whose project the board on screen does not hold, so a late create/launch response after switching boards cannot leak either.

--- a/decisions/2026/09/12/task-store-refuses-foreign-project-tasks.md
+++ b/decisions/2026/09/12/task-store-refuses-foreign-project-tasks.md
@@ -1,0 +1,30 @@
+# The task store, not its callers, decides which board holds a task
+
+## Context
+
+`currentProjectTasks` holds exactly one board's tasks. Several reducer branches append to it:
+`updateTask` (a task arriving from a push), `addTask` (creation), `spawnVariants` and
+`addAttempts` (a launch). Only `updateTask` checked the route. Creating a task into project B
+from project A's New Task dialog and pressing Launch therefore put B's card on A's board until
+the next fetch replaced it — `CreateTaskModal` guarded its own `addTask` dispatch, but nothing
+guarded the `spawnVariants` the launch dispatched right after.
+
+## Decision
+
+One helper, `acceptsTaskFrom(state, projectId)` in `src/mainview/state.ts`, answers the question
+for every appending branch: a project board takes only its own project's tasks; a space board
+takes anything, because `ProjectView` and `ActiveTasksSidebar` filter by space membership
+themselves. `updateTask`, `addTask`, `spawnVariants` and `addAttempts` all go through it, and the
+call-site guard in `CreateTaskModal` is gone — the modal reports what it created and the store
+decides.
+
+## Risks
+
+A dispatch made while no project board is on screen (dashboard, settings) is now dropped instead
+of stored. That is intended: nothing renders those cards, and the board refetches on entry.
+
+## Alternatives considered
+
+Guarding at each call site (the launch modal too) — same bug one dispatch later, and each site
+would have to learn the route. Filtering in the board component instead — cosmetic hiding that
+leaves the foreign task in the store for the split view and the task switcher to find.

--- a/src/mainview/__tests__/state.test.ts
+++ b/src/mainview/__tests__/state.test.ts
@@ -33,6 +33,12 @@ const mockTask: Task = {
 	updatedAt: "2025-01-01T00:00:00Z",
 };
 
+/** `initialState` with p1's board on screen — the store only takes tasks of the board in view. */
+const boardState: AppState = {
+	...initialState,
+	route: { screen: "project", projectId: "p1" },
+};
+
 describe("initialState", () => {
 	it("has expected defaults", () => {
 		expect(initialState).toEqual({
@@ -440,7 +446,7 @@ describe("reducer", () => {
 	});
 
 	it("addTask: appends to currentProjectTasks", () => {
-		const next = reducer(initialState, {
+		const next = reducer(boardState, {
 			type: "addTask",
 			task: mockTask,
 		});
@@ -458,6 +464,60 @@ describe("reducer", () => {
 		});
 		expect(next).toBe(state);
 		expect(next.currentProjectTasks).toHaveLength(1);
+	});
+
+	// ---- cross-project leak: the store holds ONE board's tasks ----
+	// Cmd+N on A's board, pick project B in the modal, Launch: B's card used to
+	// land on A's board until the next fetch. Every appending branch must refuse
+	// a task from a project this board does not show.
+
+	it("addTask: drops a task created into another project", () => {
+		const foreign: Task = { ...mockTask, id: "t-b", projectId: "p2" };
+		const state: AppState = { ...boardState, currentProjectTasks: [mockTask] };
+		const next = reducer(state, { type: "addTask", task: foreign });
+		expect(next).toBe(state);
+	});
+
+	it("addTask: drops a late response for the board the user just left", () => {
+		// createTask resolves after the user switched from p1 to p2.
+		const state: AppState = { ...initialState, route: { screen: "project", projectId: "p2" } };
+		const next = reducer(state, { type: "addTask", task: mockTask });
+		expect(next.currentProjectTasks).toHaveLength(0);
+	});
+
+	it("addTask: keeps a task of a member project on a space board", () => {
+		const state: AppState = {
+			...initialState,
+			route: { screen: "project", projectId: "p1", spaceId: "s1" },
+		};
+		const next = reducer(state, { type: "addTask", task: { ...mockTask, id: "t-b", projectId: "p2" } });
+		expect(next.currentProjectTasks).toHaveLength(1);
+	});
+
+	it("spawnVariants: drops variants of a task belonging to another project", () => {
+		const state: AppState = { ...boardState, currentProjectTasks: [mockTask] };
+		const foreignSource: Task = { ...mockTask, id: "t-b", projectId: "p2" };
+		const variant: Task = { ...foreignSource, id: "v-b", status: "in-progress", groupId: "g1", variantIndex: 1 };
+		const next = reducer(state, {
+			type: "spawnVariants",
+			sourceTaskId: foreignSource.id,
+			variants: [variant],
+		});
+		expect(next).toBe(state);
+		expect(next.currentProjectTasks).toEqual([mockTask]);
+	});
+
+	it("addAttempts: drops attempts of a task belonging to another project", () => {
+		const state: AppState = { ...boardState, currentProjectTasks: [mockTask] };
+		const foreignSource: Task = { ...mockTask, id: "t-b", projectId: "p2", status: "in-progress" };
+		const attempt: Task = { ...foreignSource, id: "a-b", groupId: "g1", variantIndex: 2 };
+		const next = reducer(state, {
+			type: "addAttempts",
+			sourceTaskId: foreignSource.id,
+			newAttempts: [attempt],
+			updatedSource: { ...foreignSource, groupId: "g1", variantIndex: 1 },
+		});
+		expect(next).toBe(state);
 	});
 
 	it("removeTask: removes by id", () => {
@@ -565,7 +625,7 @@ describe("reducer", () => {
 
 	it("spawnVariants: removes source task and adds variants", () => {
 		const state: AppState = {
-			...initialState,
+			...boardState,
 			currentProjectTasks: [mockTask],
 		};
 		const variant1: Task = {
@@ -610,7 +670,7 @@ describe("reducer", () => {
 			configId: "claude-default",
 		};
 		const state: AppState = {
-			...initialState,
+			...boardState,
 			// Source task + variant already added by updateTask push
 			currentProjectTasks: [mockTask, variant1],
 		};
@@ -626,7 +686,7 @@ describe("reducer", () => {
 	it("spawnVariants: preserves other tasks", () => {
 		const otherTask: Task = { ...mockTask, id: "t2", title: "Other" };
 		const state: AppState = {
-			...initialState,
+			...boardState,
 			currentProjectTasks: [mockTask, otherTask],
 		};
 		const variant1: Task = {
@@ -656,7 +716,7 @@ describe("reducer", () => {
 			branchName: "feat/test",
 		};
 		const state: AppState = {
-			...initialState,
+			...boardState,
 			currentProjectTasks: [sourceTask],
 		};
 		const updatedSource: Task = {
@@ -699,7 +759,7 @@ describe("reducer", () => {
 			variantIndex: 2,
 		};
 		const state: AppState = {
-			...initialState,
+			...boardState,
 			currentProjectTasks: [sourceTask, attempt],
 		};
 		const next = reducer(state, {

--- a/src/mainview/components/CreateTaskModal.tsx
+++ b/src/mainview/components/CreateTaskModal.tsx
@@ -435,12 +435,9 @@ function CreateTaskModal({ project: initialProject, projects, dispatch, initialT
 			// if a follow-up (renameTask/setTaskLabels) fails, deferring the
 			// dispatch would leave an invisible orphan and tempt a duplicate on
 			// retry. Title/labels are non-fatal follow-ups on the created task.
-			// A task created in another project must not be added to the board the
-			// user is currently viewing; its persisted taskUpdated events will load
-			// it when that project is opened.
-			if (created.projectId === initialProject.id) {
-				dispatch({ type: "addTask", task: created });
-			}
+			// A task created into another project is dropped by the reducer, which
+			// owns "does this board hold it" — it loads when that project is opened.
+			dispatch({ type: "addTask", task: created });
 			let task = created;
 			let followUpError: unknown = null;
 			try {

--- a/src/mainview/components/__tests__/CreateTaskModal.test.tsx
+++ b/src/mainview/components/__tests__/CreateTaskModal.test.tsx
@@ -219,7 +219,10 @@ describe("CreateTaskModal", () => {
 			});
 			expect(onCreateAndRun).toHaveBeenCalledWith(otherTask, otherProject);
 		});
-		expect(dispatch).not.toHaveBeenCalledWith({ type: "addTask", task: otherTask });
+		// The modal always reports the created task; the reducer decides whether the
+		// board on screen holds it (see "addTask: drops a task created into another
+		// project" in state.test.ts).
+		expect(dispatch).toHaveBeenCalledWith({ type: "addTask", task: otherTask });
 	});
 
 	it("shows dual hint text when onCreateAndRun is provided", () => {

--- a/src/mainview/state.ts
+++ b/src/mainview/state.ts
@@ -237,6 +237,27 @@ function boardSpaceId(route: Route): string | null {
 }
 
 /**
+ * May a task from `projectId` enter the task store as it stands right now?
+ *
+ * The store holds exactly one board's tasks, so every branch that APPENDS one
+ * has to ask — a task created into another project from the picker, the
+ * variants a launch spawns for it, a response arriving after the user switched
+ * boards. Without this the card lands on the board the user is looking at until
+ * the next fetch replaces it.
+ *
+ * A space board holds several projects and filters its own cards by membership
+ * (ProjectView), so there the board decides and the store only has to keep them.
+ */
+function acceptsTaskFrom(state: AppState, projectId: string): boolean {
+	if (boardSpaceId(state.route) !== null) return true;
+	const viewingProjectId =
+		state.route.screen === "project" || state.route.screen === "task" || state.route.screen === "project-settings"
+			? state.route.projectId
+			: null;
+	return viewingProjectId !== null && projectId === viewingProjectId;
+}
+
+/**
  * Identity of the set of tasks a route's board holds. Changing it empties the
  * cached task list, so zooming out to a space refetches instead of rendering the
  * one project's cards as if they were the whole space.
@@ -460,27 +481,17 @@ export function reducer(state: AppState, action: AppAction): AppState {
 					),
 				};
 			}
-			// New task (e.g. created via CLI) — add if we're viewing the same project.
-			// On a space board every member project is on screen, so the board itself
-			// decides which cards belong; the store only has to keep them.
-			const viewingProjectId =
-				state.route.screen === "project" || state.route.screen === "task" || state.route.screen === "project-settings"
-					? state.route.projectId
-					: null;
-			if (boardSpaceId(state.route) !== null) {
-				return { ...state, currentProjectTasks: [...state.currentProjectTasks, action.task] };
-			}
-			if (viewingProjectId && action.task.projectId === viewingProjectId) {
-				return {
-					...state,
-					currentProjectTasks: [...state.currentProjectTasks, action.task],
-				};
-			}
-			return state;
+			// New task (e.g. created via CLI) — add only if this board holds it.
+			if (!acceptsTaskFrom(state, action.task.projectId)) return state;
+			return {
+				...state,
+				currentProjectTasks: [...state.currentProjectTasks, action.task],
+			};
 		}
 		case "addTask":
 			if (state.currentProjectTasks.some((t) => t.id === action.task.id))
 				return state;
+			if (!acceptsTaskFrom(state, action.task.projectId)) return state;
 			return {
 				...state,
 				currentProjectTasks: [...state.currentProjectTasks, action.task],
@@ -502,27 +513,24 @@ export function reducer(state: AppState, action: AppAction): AppState {
 			// Collect variant IDs to filter out any duplicates already added
 			// by a concurrent pushMessage("taskUpdated") race
 			const variantIds = new Set(action.variants.map((v) => v.id));
-			return {
-				...state,
-				currentProjectTasks: [
-					...state.currentProjectTasks.filter(
-						(t) => t.id !== action.sourceTaskId && !variantIds.has(t.id),
-					),
-					...action.variants,
-				],
-			};
+			// Launching a task that belongs to another project must not put its
+			// variants on the board in view (create-in-B-then-Launch-from-A).
+			const variants = action.variants.filter((v) => acceptsTaskFrom(state, v.projectId));
+			const kept = state.currentProjectTasks.filter(
+				(t) => t.id !== action.sourceTaskId && !variantIds.has(t.id),
+			);
+			if (variants.length === 0 && kept.length === state.currentProjectTasks.length) return state;
+			return { ...state, currentProjectTasks: [...kept, ...variants] };
 		}
 		case "addAttempts": {
 			const attemptIds = new Set(action.newAttempts.map((v) => v.id));
-			return {
-				...state,
-				currentProjectTasks: [
-					...state.currentProjectTasks
-						.filter((t) => !attemptIds.has(t.id))
-						.map((t) => t.id === action.sourceTaskId ? action.updatedSource : t),
-					...action.newAttempts,
-				],
-			};
+			const attempts = action.newAttempts.filter((v) => acceptsTaskFrom(state, v.projectId));
+			const onBoard = state.currentProjectTasks.some((t) => t.id === action.sourceTaskId || attemptIds.has(t.id));
+			if (attempts.length === 0 && !onBoard) return state;
+			const kept = state.currentProjectTasks
+				.filter((t) => !attemptIds.has(t.id))
+				.map((t) => t.id === action.sourceTaskId ? action.updatedSource : t);
+			return { ...state, currentProjectTasks: [...kept, ...attempts] };
 		}
 		case "addProject": {
 			const normalizedPath = normalizeProjectPath(action.project.path);


### PR DESCRIPTION
Creating a task into another project from the New Task dialog and pressing Launch put that task's card on the board you were looking at, until the next fetch replaced it.

`CreateTaskModal` already refused to dispatch `addTask` for another project, but the launch that follows does not use that path: `LaunchVariantsModal` dispatches `spawnVariants`, and that reducer branch appended the returned tasks to `currentProjectTasks` with no project check at all. On a single-project board `ProjectView` passes the store straight to `KanbanBoard`, so the foreign card rendered. `addAttempts` had the same hole, and the call-site guard compared against the modal's initial project rather than the live route, so a response landing after the user switched boards leaked too.

One helper in `src/mainview/state.ts` — `acceptsTaskFrom(state, projectId)` — now answers the question for every branch that appends to the task store: `updateTask`, `addTask`, `spawnVariants`, `addAttempts`. A project board takes only its own project's tasks; a space board takes anything, because `ProjectView` and `ActiveTasksSidebar` filter by space membership themselves (unchanged behaviour). The redundant guard in `CreateTaskModal` is gone: the modal reports what it created, the store decides whether the board on screen holds it.

Persistence, project assignment and the launch itself are untouched. Five new reducer cases cover the create half, the launch half, `addAttempts`, a late response arriving after a board switch, and the space-board exemption; rationale is in `decisions/2026/09/12/task-store-refuses-foreign-project-tasks.md`.

Verified in a browser on a scoped QA board with two projects: before the fix, B's card lands in A's "Agent is Working"; after it, A's board stays empty while B holds the task exactly once, and same-project create and create-and-launch still show their card immediately.

---

🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=6b91101b-ffb2-483f-8984-1ae92c46517c) · `dev3://task/6b91101b-ffb2-483f-8984-1ae92c46517c` _(dev3 added this footer — turn it off in Settings → Tasks.)_