### PR TITLE
Fix the two Windows-only test breaks gating canary publishing

### DIFF
--- a/change-logs/2026/09/12/fix-canary-publish-windows-proof-gate.md
+++ b/change-logs/2026/09/12/fix-canary-publish-windows-proof-gate.md
@@ -1,0 +1,3 @@
+Short: Canary publishing works again
+
+Canary publishing stopped producing builds because two Windows-only test failures broke the packaged Windows proof that gates every canary build job. The golden agent-command matrix did not account for Claude's protocol-body path being quoted on Windows, and the new dev-server tmux capture test ran on Windows where the tmux backend does not exist.

--- a/src/bun/__tests__/agent-command-golden.test.ts
+++ b/src/bun/__tests__/agent-command-golden.test.ts
@@ -36,8 +36,12 @@ function redact(cmd: string): string {
 	// whole, so its apostrophes are rewritten ('→'\''). Redact the escaped inner.
 	const genericEscapedInner = shellEscape(DEV3_SYSTEM_PROMPT_GENERIC).slice(1, -1);
 	return cmd
-		// Claude's body travels in a file whose path is machine specific.
-		.replace(/\S*[/\\]agent-prompts[/\\]claude\.md/g, "<CLAUDE_BODY_FILE>")
+		// Claude's body travels in a file whose path is machine specific. A Windows
+		// path holds backslashes, so `quoteIfUnsafe` wraps it and the sentinel has to
+		// swallow BOTH quotes — matching only the path left the closing one behind and
+		// every claude case failed on the Windows runner alone (Seq 1917). The
+		// backreference keeps the pair symmetric: a genuinely lost quote still fails.
+		.replace(/(['"]?)[^\s'"]*[/\\]agent-prompts[/\\]claude\.md\1/g, "<CLAUDE_BODY_FILE>")
 		.split(claudeBody).join("<CLAUDE_BODY>")
 		.split(codexBody).join("<CODEX_DEV_INSTR>")
 		.split(genericEscapedInner).join("<GENERIC_BODY>");
@@ -242,6 +246,18 @@ describe("resolveAgentCommand — golden matrix (structural, byte-identical)", (
 	it.each(cases.map((c) => [c.name, c] as const))("%s", async (_name, c) => {
 		const out = await resolveAgentCommand(agent(c.base), c.config, c.ctx ?? CTX, c.options);
 		expect(redact(out)).toBe(EXPECTED[c.name]);
+	});
+
+	// The matrix above only ever sees THIS runner's path, so a Windows-shaped one —
+	// quoted, because of its backslashes — is never redacted on a POSIX box and the
+	// break showed up only in the post-merge Windows job. Feed the shape in directly.
+	it("redacts a quoted Windows body-file path, quotes and all", () => {
+		const winCmd =
+			"claude --append-system-prompt-file 'C:\\Users\\runneradmin\\.dev3.0\\data\\agent-prompts\\claude.md' -- 'Fix the login bug'";
+		expect(redact(winCmd)).toBe("claude --append-system-prompt-file <CLAUDE_BODY_FILE> -- 'Fix the login bug'");
+
+		const posixCmd = "claude --append-system-prompt-file /home/r/.dev3.0/data/agent-prompts/claude.md";
+		expect(redact(posixCmd)).toBe("claude --append-system-prompt-file <CLAUDE_BODY_FILE>");
 	});
 });
 

--- a/src/bun/rpc-handlers/__tests__/dev-server-pane-launch.test.ts
+++ b/src/bun/rpc-handlers/__tests__/dev-server-pane-launch.test.ts
@@ -190,7 +190,10 @@ describe(`dev-server pane launch on ${process.platform}`, () => {
 		expect(String(spec.outputLogPath)).toMatch(/[/\\]abcdef12[/\\]logs[/\\]dev-server\.log$/);
 	});
 
-	it("chains the tmux capture onto new-session itself, not as a later command", async () => {
+	// POSIX-only by construction: the tmux backend does not exist on Windows, where
+	// `runDevServer` refuses a tmux task before it reaches the capture. Running it
+	// there asserted nothing and failed the packaged Windows job outright (Seq 1917).
+	it.skipIf(isWindows)("chains the tmux capture onto new-session itself, not as a later command", async () => {
 		mocks.getTask.mockResolvedValue(TMUX_TASK);
 		await runDevServer({ taskId: TMUX_TASK.id, projectId: PROJECT.id });
 		const calls = mocks.newSessionDetached.mock.calls as unknown as Array<[{ pipeTo?: string; command?: string }]>;


### PR DESCRIPTION
Canary publishing has produced nothing since 09:08 UTC today. It never reached the publishing
step: the gating `windows-proof` job (`.github/workflows/windows-conpty-package.yml`) failed, and
every canary build job plus `release-page` declares it as `needs:`, so all five `build-*` jobs and
`release-page` are `skipped` in all nine failed runs. No canary asset was produced or uploaded, no
tag moved — the `canary` pre-release still points at `1.53.0+canary.d2dc5912` from the last green
run (08:10 UTC). Nothing broken was published; the channel simply stopped moving.

Two independent Windows-only test breaks, both merged this morning, are the recurring cause.
Attribution is by ancestry (`git merge-base --is-ancestor`), not by timestamp: `4b7af9cd` contains
cause A only and fails only the golden step, `f15f3754` onward contains both.

**Cause A — `6add5c9f1` (#1738), 16 failing cases.** The golden agent-command matrix redacts
Claude's machine-specific protocol-body path to `<CLAUDE_BODY_FILE>` with a pattern that matched
the path alone. On Windows that path holds backslashes, so `quoteIfUnsafe` wraps it in quotes;
`\S*` swallowed the opening quote as part of the path and the closing one survived redaction,
leaving `<CLAUDE_BODY_FILE>'`. Every `claude/*` case failed. The launch command itself was correct
— only the test's redaction was wrong. The pattern now matches a symmetric quote pair through a
backreference, so a genuinely lost quote still fails the matrix.

A new case feeds a Windows-shaped quoted path straight into the redaction helper, so a POSIX
runner catches this class. Proven rather than assumed: with the old pattern restored it fails on
macOS with the exact CI symptom, and passes with the fix.

**Cause B — `f15f3754f` (#1749).** The new "chains the tmux capture onto new-session itself" case
drives a tmux-backend task through `runDevServer` with no platform override, so on a real Windows
runner it hits `assertPosixLaunchDialect`. Its siblings that need Windows behaviour use the file's
own `asWindows()` helper; this one needed the opposite and got neither. It is now
`it.skipIf(isWindows)` — the tmux backend has no Windows equivalent, so on Windows the case
asserted nothing and only failed. POSIX CI still runs it.

No product code is touched; both defects are in tests.

Both breaks reached `main` green because the packaged Windows proof deliberately does not gate
pull requests (`decisions/2026/08/06/windows-proof-post-merge-not-pull-request.md`), so a
Windows-only test break is invisible until it is already on `main` and blocking canary.

Cause B cannot be executed on a macOS box: the packaged Windows job on the merge commit is the
first real evidence for it.

---

🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=3d1ba249-caf5-4e65-b93f-f7fb36cd312a) · `dev3://task/3d1ba249-caf5-4e65-b93f-f7fb36cd312a` _(dev3 added this footer — turn it off in Settings → Tasks.)_