### PR TITLE
Clip a traffic project heading to the room before its neighbour

### DIFF
--- a/change-logs/2026/09/12/fix-traffic-project-heading-overlap.md
+++ b/change-logs/2026/09/12/fix-traffic-project-heading-overlap.md
@@ -1,0 +1,3 @@
+Short: Project names stop overlapping when zoomed out
+
+In Agent traffic, a project name no longer runs through its neighbour's at strong zoom-out. Project names render at a fixed screen size while the gap between two project frames shrinks with the zoom, so a narrow project's name used to cross into the next one and leave both unreadable; each name is now clipped to the room it actually has before the next project starts.

--- a/src/mainview/__tests__/traffic-group-heading.test.ts
+++ b/src/mainview/__tests__/traffic-group-heading.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+	headingRoom,
 	headingTop,
 	headingWidth,
 } from "../components/agent-traffic/group-heading";
@@ -33,5 +34,69 @@ describe("headingWidth", () => {
 	it("stays readable when the group shrinks to a few pixels", () => {
 		// A 300-wide group at 14% is 42px on screen — "rts-do…" and nothing more.
 		expect(headingWidth(CARD_WIDTH, 0.14)).toBe(150);
+	});
+
+	it("never reaches the next project's name", () => {
+		// Two groups 524 scene units apart at 14%: 73px on screen, so the 150px
+		// minimum would run straight through the neighbour's name.
+		expect(headingWidth(364, 0.14, 524)).toBeLessThan(524 * 0.14);
+		expect(headingWidth(364, 0.14, 524)).toBeGreaterThan(0);
+	});
+
+	it("keeps the full width when the neighbour is far away", () => {
+		expect(headingWidth(600, 1, 4000)).toBe(552);
+		expect(headingWidth(600, 1)).toBe(552);
+	});
+
+	it("gives up rather than show a smudge when two groups nearly touch", () => {
+		// 200 scene units at 5% leave 10px on screen: less than one word.
+		expect(headingWidth(364, 0.05, 200)).toBe(0);
+	});
+
+	it("keeps the reported pair of names apart on screen", () => {
+		// The screenshot: a one-card project (364 wide) 160 units left of a six-column
+		// one, at 14%. Headings sit 24 scene units inside their frame, so on screen
+		// the first name may not reach where the second one starts.
+		const scale = 0.14;
+		const narrow = { x: 0, y: 0, width: 364, height: 500 };
+		const wide = { x: 524, y: 0, width: 2060, height: 2600 };
+		const room = headingRoom(narrow, [narrow, wide]);
+		const right = (narrow.x + 24) * scale + headingWidth(narrow.width, scale, room);
+		expect(right).toBeLessThan((wide.x + 24) * scale);
+	});
+
+	it("never asks for more room than it was given", () => {
+		for (const scale of [0.05, 0.14, 0.36, 0.7, 1, 2.2])
+			for (const room of [200, 524, 900, 2400]) {
+				const width = headingWidth(364, scale, room);
+				expect(width).toBeLessThanOrEqual(Math.max(0, room * scale - 14));
+			}
+	});
+});
+
+describe("headingRoom", () => {
+	const row = [
+		{ x: 0, y: 0, width: 364, height: 500 },
+		{ x: 524, y: 0, width: 1700, height: 900 },
+	];
+
+	it("measures to the next group standing on the same band", () => {
+		expect(headingRoom(row[0], row)).toBe(524);
+	});
+
+	it("is unbounded for the last group on its band", () => {
+		expect(headingRoom(row[1], row)).toBe(Number.POSITIVE_INFINITY);
+	});
+
+	it("ignores a group on another row, however wide it is", () => {
+		const below = { x: 100, y: 1200, width: 2000, height: 600 };
+		expect(headingRoom(row[0], [...row, below])).toBe(524);
+		expect(headingRoom(row[1], [...row, below])).toBe(Number.POSITIVE_INFINITY);
+	});
+
+	it("takes the nearest of several groups to the right", () => {
+		const third = { x: 700, y: 0, width: 300, height: 400 };
+		expect(headingRoom(row[0], [...row, third])).toBe(524);
+		expect(headingRoom(row[0], [row[0], third])).toBe(700);
 	});
 });

--- a/src/mainview/components/agent-traffic/TrafficNodes.tsx
+++ b/src/mainview/components/agent-traffic/TrafficNodes.tsx
@@ -61,7 +61,7 @@ import TrafficMinimap from "./TrafficMinimap";
 import TrafficMessageBubble from "./TrafficMessageBubble";
 import TrafficNotificationCloud from "./TrafficNotificationCloud";
 import { cellSeqFontSize, cellSeqInk } from "./cell-seq";
-import { headingTop, headingWidth } from "./group-heading";
+import { headingRoom, headingTop, headingWidth } from "./group-heading";
 import { IDENTITY_SCALE, MAX_SCALE, SCENE_PAD_Y, detailTier, frameExchange, overviewScale } from "./traffic-camera";
 
 interface Props {
@@ -244,6 +244,17 @@ export default function TrafficNodes({
 	placedRef.current = scene.placed;
 	/** Where the person stands right now, or null when nobody is speaking. */
 	const speakerRef = useRef<SpeakerPlacement | null>(null);
+	/** Scene room each project name has before the next one starts. */
+	const headingRooms = useMemo(
+		() =>
+			new Map(
+				scene.groups.map((group) => [
+					group.projectId,
+					headingRoom(group, scene.groups),
+				]),
+			),
+		[scene.groups],
+	);
 	const projectById = useMemo(
 		() => new Map((projects ?? []).map((project) => [project.id, project])),
 		[projects],
@@ -846,7 +857,7 @@ export default function TrafficNodes({
 			>
 				{scene.groups.map(group => (
 					<div key={group.projectId} className="traffic-project-group" style={{ left: group.x, top: group.y, width: group.width, height: group.height }}>
-						<div className="traffic-project-heading" style={{ top: headingTop(view.scale), transform: `scale(${1 / view.scale})`, width: headingWidth(group.width, view.scale) }}>
+						<div className="traffic-project-heading" style={{ top: headingTop(view.scale), transform: `scale(${1 / view.scale})`, width: headingWidth(group.width, view.scale, headingRooms.get(group.projectId)) }}>
 							{projectById.get(group.projectId)?.name ?? t("traffic.orbit.project")}
 						</div>
 					</div>

--- a/src/mainview/components/agent-traffic/group-heading.ts
+++ b/src/mainview/components/agent-traffic/group-heading.ts
@@ -4,6 +4,18 @@ import { SCENE_PAD_Y } from "./traffic-camera";
 const HEADING_LIFT = 22;
 /** Screen width a project name gets even when its group is narrower than that. */
 const MIN_HEADING_WIDTH = 150;
+/** Screen gap kept between one project's name and the next name on its row. */
+const HEADING_GUTTER = 14;
+/** Screen width below which a clipped name carries nothing and is dropped. */
+const LEGIBLE_HEADING_WIDTH = 28;
+
+/** A group frame on the stage, in scene units — what a heading hangs above. */
+export interface HeadingFrame {
+	x: number;
+	y: number;
+	width: number;
+	height: number;
+}
 
 /**
  * Where a project name sits, in scene units, above its group frame.
@@ -19,10 +31,39 @@ export function headingTop(scale: number): number {
 }
 
 /**
+ * Scene distance from this group's name to the next name that could collide with
+ * it: the nearest group to the right whose frame shares any of its vertical band.
+ * `Infinity` when nothing stands to the right — the heading is then free to
+ * overhang into empty canvas.
+ */
+export function headingRoom(group: HeadingFrame, groups: HeadingFrame[]): number {
+	let room = Number.POSITIVE_INFINITY;
+	for (const other of groups) {
+		if (other === group || other.x <= group.x) continue;
+		const sameBand =
+			other.y < group.y + group.height && other.y + other.height > group.y;
+		if (sameBand) room = Math.min(room, other.x - group.x);
+	}
+	return room;
+}
+
+/**
  * Screen width the heading may use. A group zoomed down to 35px wide would clip
  * its own name to two letters, which is the same as having no name at all, so a
- * short name is allowed to overhang the frame it belongs to.
+ * short name is allowed to overhang the frame it belongs to — but never as far as
+ * its neighbour's name. Both headings are screen-sized while the gap between two
+ * groups is scene-sized, so zooming out shrinks the gap and not the labels: past
+ * some zoom a narrow group's name runs straight through the next one and both
+ * become unreadable. `room` (from [[headingRoom]]) is the ceiling that prevents it.
  */
-export function headingWidth(groupWidth: number, scale: number): number {
-	return Math.max(MIN_HEADING_WIDTH, (groupWidth - 48) * scale);
+export function headingWidth(
+	groupWidth: number,
+	scale: number,
+	room = Number.POSITIVE_INFINITY,
+): number {
+	const natural = Math.max(MIN_HEADING_WIDTH, (groupWidth - 48) * scale);
+	const allowed = Math.min(natural, room * scale - HEADING_GUTTER);
+	// Two or three glyph columns are a smudge, not a name; nothing reads better
+	// than a fragment of one letter sitting on the frame's corner.
+	return allowed < LEGIBLE_HEADING_WIDTH ? 0 : allowed;
 }


### PR DESCRIPTION
In Agent traffic (Experiment 2), a project name could be written straight through its neighbour's at strong zoom-out, leaving both unreadable.

**Cause.** The name renders at a fixed screen size (it carries the inverse zoom) while the gap between two group frames is measured in scene units, so zooming out shrinks the gap and not the labels. On top of that, `headingWidth` guaranteed every name 150 screen px so a narrow project would not clip itself to two letters. Below roughly 20% those two rules collide: a one-card project is ~51px wide on screen with ~22px to the next project, and its 150px name crosses into the next one. It is not about one long string — any adjacent pair hits it once the zoom is low enough.

**Fix.** `headingRoom(group, groups)` measures the scene distance to the nearest group to the right that shares this group's vertical band (`Infinity` when nothing stands there, so a heading over empty canvas is unchanged). `headingWidth` now caps the natural width at `room * scale - 14px`, so a name can never reach where the next name starts, and drops the name below 28 screen px rather than drawing a glyph fragment. `TrafficNodes` memoizes the room per project off `scene.groups`. Layout, camera, fit/follow, frames, wires and selection are untouched — only the width of a `div` that was already there.

**Verification.** `traffic-group-heading.test.ts` covers the reported geometry (364-wide group, 160-unit gap, 14% zoom) plus a sweep over six zooms and four gaps; replacing the clamp with the old width fails four of those tests. Lint clean, 169 tests green across `traffic-group-heading`, `nodes-layout`, `agent-traffic-ui`, `traffic-camera`, `traffic-minimap`. Browser QA on a throwaway board seeded with four projects (a one-task project with a long name next to a 26-task one, and a second row of two more) reproduced the overlap and confirmed it gone at 14%, 34%, on a resized viewport and at fit zoom, with no console errors.

---

🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=aaeada07-06dc-4b21-b425-3ab913d73b1c) · `dev3://task/aaeada07-06dc-4b21-b425-3ab913d73b1c` _(dev3 added this footer — turn it off in Settings → Tasks.)_