### PR TITLE
Fix orphaned model proxies across app restarts

### DIFF
--- a/change-logs/2026/09/13/fix-model-proxy-orphans.md
+++ b/change-logs/2026/09/13/fix-model-proxy-orphans.md
@@ -1,0 +1,3 @@
+Short: Keep model routes through restarts
+
+Model proxies are signalled immediately when dev3 quits, including during startup. On supported systems, restarting reclaims a verified orphan only on the address the replacement will use, preserving the session key while leaving other live instances and legacy routes alone.

--- a/decisions/2026/08/15/model-catalog-and-model-roles.md
+++ b/decisions/2026/08/15/model-catalog-and-model-roles.md
@@ -136,6 +136,8 @@ is written literally — it is a URL, not a credential.
 
 ## Follow-up: the endpoint is remembered, not fresh per start
 
+Superseded on 2026-09-13 by `decisions/2026/09/13/model-proxy-dies-with-the-app.md`: a squatter may be our own orphan, so verify ownership and reclaim only the address the replacement will take before falling back.
+
 The first implementation picked a fresh ephemeral port and a fresh session key on every start,
 described as a per-run secret. That is wrong for a sidecar other processes talk to: an agent's
 `ANTHROPIC_BASE_URL` and token are baked into its launch environment, so restarting the app —

--- a/decisions/2026/09/13/model-proxy-dies-with-the-app.md
+++ b/decisions/2026/09/13/model-proxy-dies-with-the-app.md
@@ -1,0 +1,23 @@
+# The model proxy dies with the app
+
+## Context
+
+Routed agents retain their proxy address and local session key across app restarts. Deferred quit cleanup leaked proxies with provider credentials, while occupied ports made later starts choose new addresses and strand existing sessions.
+
+## Investigation
+
+Electrobun's `Utils.quit()` emits `before-quit` synchronously and then calls native shutdown and force-exit: a dynamic import or an awaited descendant scan cannot reliably signal the proxy first. The current `buildProcessTree()` uses cached `args` output and exposes no executable identity, so reclaim instead needs fresh `ps -eo pid=,ppid=,comm=` plus `lsof -a -p <pid> -Fn`, matching both runtime databases through the real directory path.
+
+## Decision
+
+`killModelSidecarNow()` in `src/bun/model-sidecar.ts` synchronously signals the running or starting child and blocks further starts; `src/bun/index.ts` imports and invokes it inline. Async RPC stops retain their port-release wait. `endpoint.json` adds optional `pid` and `ownerPid` fields without changing its location or the existing port/key fields; older readers and writers remain supported.
+
+Startup reclaims only the address it will take, in the existing default-then-remembered order, and binds that reclaimed address first. A listener must match the proxy executable and both database paths, have no live non-init parent, and have no live recorded owner before `terminatePidsVerified` signals it; other ports and other instances are left untouched.
+
+## Risks
+
+Unknown identity or owner liveness fails closed, including permission errors and Windows without `ps`/`lsof`; PID metadata alone is not permission to kill. A port can still be taken between inspection and bind, and PID reuse during inspection cannot be eliminated without OS process handles. Existing agents on unselected legacy ports are not migrated, and the shared endpoint file cannot preserve every address across multiple instances.
+
+## Alternatives considered
+
+Adopting an orphan retains stale configuration and loses lifecycle/output ownership. Killing every orphan strands agents on addresses no replacement will serve, while trusting PIDs alone can kill unrelated processes after reuse. Async quit cleanup repeats the original race; a synchronous descendant scan delays quit unnecessarily for a proxy with no children.

--- a/src/bun/__tests__/model-sidecar-quit.test.ts
+++ b/src/bun/__tests__/model-sidecar-quit.test.ts
@@ -1,0 +1,30 @@
+import { readFileSync } from "node:fs";
+import ts from "typescript";
+import { describe, expect, it, vi } from "vitest";
+
+const source = ts.createSourceFile("index.ts", readFileSync(new URL("../index.ts", import.meta.url), "utf8"), ts.ScriptTarget.Latest, true);
+
+describe("global quit proxy cleanup", () => {
+	it("statically imports the synchronous kill and calls it before cleanup returns", () => {
+		const imported = source.statements.filter(ts.isImportDeclaration).find((node) =>
+			ts.isStringLiteral(node.moduleSpecifier) && node.moduleSpecifier.text === "./model-sidecar");
+		expect(imported?.getText(), "index.ts must statically import killModelSidecarNow for the synchronous quit gate")
+			.toContain("killModelSidecarNow");
+		const cleanup = source.statements.filter(ts.isFunctionDeclaration).find((node) => node.name?.text === "runGlobalQuitCleanup");
+		expect(cleanup?.body, "runGlobalQuitCleanup moved; update this focused bootstrap test").toBeDefined();
+
+		// Execute the actual cleanup body without booting Electrobun or its pollers.
+		const names = new Set<string>(["log"]);
+		const visit = (node: ts.Node): void => {
+			if (ts.isCallExpression(node) && ts.isIdentifier(node.expression)) names.add(node.expression.text);
+			ts.forEachChild(node, visit);
+		};
+		visit(cleanup!);
+		const kill = vi.fn();
+		const values = [...names].map((name) => name === "log" ? { info: vi.fn(), warn: vi.fn() } : name === "killModelSidecarNow" ? kill : vi.fn());
+		const javascript = ts.transpileModule(cleanup!.getText(), { compilerOptions: { target: ts.ScriptTarget.ES2022 } }).outputText;
+		const run = new Function(...names, `${javascript}; return runGlobalQuitCleanup;`)(...values) as () => void;
+		run();
+		expect(kill).toHaveBeenCalledExactlyOnceWith();
+	});
+});

--- a/src/bun/__tests__/model-sidecar.test.ts
+++ b/src/bun/__tests__/model-sidecar.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi, type MockInstance } from "vitest";
 import { createServer } from "node:net";
 import type { AddressInfo } from "node:net";
 import type { ModelCatalog } from "../../shared/model-catalog";
@@ -6,6 +6,8 @@ import type { ModelCatalog } from "../../shared/model-catalog";
 const h = vi.hoisted(() => ({
 	spawnMock: vi.fn(),
 	getDescendantPids: vi.fn<(pid: number) => Promise<number[]>>(),
+	findPortHolders: vi.fn(),
+	freePorts: null as Set<number> | null,
 	fs: {
 		existsSync: vi.fn((p: string) => p === "/opt/dev3/bifrost-http"),
 		mkdirSync: vi.fn(),
@@ -14,14 +16,40 @@ const h = vi.hoisted(() => ({
 		}),
 		writeFileSync: vi.fn(),
 		chmodSync: vi.fn(),
-		realpathSync: vi.fn(() => "/apps/dev3.app/Contents/MacOS/bun"),
+		appendFileSync: vi.fn(),
+		realpathSync: vi.fn((_path?: string) => "/apps/dev3.app/Contents/MacOS/bun"),
 	},
 	catalog: vi.fn<() => ModelCatalog>(),
 	keys: vi.fn<() => Record<string, string>>(),
 }));
 
 vi.mock("../spawn", () => ({ spawn: h.spawnMock }));
-vi.mock("../port-scanner", () => ({ getDescendantPids: h.getDescendantPids }));
+vi.mock("node:net", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("node:net")>();
+	return {
+		...actual,
+		createServer: (...args: Parameters<typeof actual.createServer>) => {
+			if (!h.freePorts) return actual.createServer(...args);
+			let error!: () => void;
+			let port = 0;
+			const server = {
+				unref() {},
+				once(_event: string, callback: () => void) { error = callback; },
+				listen(options: { port: number }, callback: () => void) {
+					port = options.port || 47312;
+					queueMicrotask(() => options.port === 0 || h.freePorts?.has(port) ? callback() : error());
+				},
+				address: () => ({ port }),
+				close(callback?: () => void) { callback?.(); },
+			};
+			return server;
+		},
+	};
+});
+vi.mock("../port-scanner", () => ({
+	getDescendantPids: h.getDescendantPids,
+	findPortHolders: h.findPortHolders,
+}));
 vi.mock("node:fs", () => h.fs);
 vi.mock("../paths", () => ({ DEV3_HOME: "/tmp/dev3-model-catalog-test" }));
 vi.mock("../model-catalog-store", () => ({
@@ -99,6 +127,10 @@ beforeEach(() => {
 	vi.unstubAllGlobals();
 	process.env.DEV3_BIFROST_BINARY = "/opt/dev3/bifrost-http";
 	h.getDescendantPids.mockResolvedValue([]);
+	h.findPortHolders.mockResolvedValue([]);
+	h.freePorts = null;
+	h.fs.realpathSync.mockImplementation((path?: string) =>
+		path?.includes("model-catalog-runtime") ? path : "/apps/dev3.app/Contents/MacOS/bun");
 	h.catalog.mockReturnValue(CATALOG);
 	h.keys.mockReturnValue({ "p-or": "sk-or-live", "p-custom": "sk-custom" });
 	h.fs.existsSync.mockImplementation((p: string) => p === "/opt/dev3/bifrost-http");
@@ -108,6 +140,15 @@ beforeEach(() => {
 	h.spawnMock.mockImplementation(() => liveProcess());
 	stubHttp();
 });
+
+afterEach(() => vi.restoreAllMocks());
+
+function remember(endpoint: unknown) {
+	h.fs.readFileSync.mockImplementation((target: string) => {
+		if (String(target).endsWith("endpoint.json")) return JSON.stringify(endpoint);
+		throw new Error("ENOENT");
+	});
+}
 
 describe("binary resolution", () => {
 	it("prefers an explicit development override", async () => {
@@ -247,16 +288,9 @@ describe("starting", () => {
 
 describe("surviving a restart", () => {
 	/** What the last start wrote to endpoint.json, or null. */
-	function rememberedEndpoint(): { port: number; sessionKey: string } | null {
+	function rememberedEndpoint(): { port: number; sessionKey: string; pid: number; ownerPid: number } | null {
 		const call = h.fs.writeFileSync.mock.calls.find(([target]) => String(target).endsWith("endpoint.json"));
 		return call ? JSON.parse(String(call[1])) : null;
-	}
-
-	function remember(endpoint: unknown) {
-		h.fs.readFileSync.mockImplementation((target: string) => {
-			if (String(target).endsWith("endpoint.json")) return JSON.stringify(endpoint);
-			throw new Error("ENOENT");
-		});
 	}
 
 	it("remembers the port and the session key it launched on", async () => {
@@ -266,6 +300,21 @@ describe("surviving a restart", () => {
 		expect(saved).toBeTruthy();
 		expect(runtime.baseUrl).toBe(`http://127.0.0.1:${saved?.port}`);
 		expect(saved?.sessionKey).toBe(runtime.sessionKey);
+		expect(saved?.pid).toBe(5150);
+		expect(saved?.ownerPid).toBe(process.pid);
+	});
+
+	it("loads endpoints written before ownership was recorded", async () => {
+		const endpoint = { port: 47311, sessionKey: "sk-bf-rememberedkey" };
+		remember(endpoint);
+		const { loadSidecarEndpoint } = await freshModule();
+		expect(loadSidecarEndpoint()).toEqual(endpoint);
+	});
+
+	it.each([0, -1, 1, 1.5, "123"])("ignores invalid ownership pid %s", async (pid) => {
+		remember({ port: 47311, sessionKey: "sk-bf-rememberedkey", pid, ownerPid: pid });
+		const { loadSidecarEndpoint } = await freshModule();
+		expect(loadSidecarEndpoint()).toEqual({ port: 47311, sessionKey: "sk-bf-rememberedkey" });
 	});
 
 	// A running agent has the base URL and token baked into its launch env, so a
@@ -355,6 +404,186 @@ describe("choosing the port", () => {
 	});
 });
 
+describe("reclaiming leaked proxies", () => {
+	const PROXY = 7001;
+	const OWNER = 7002;
+	const OTHER_PROXY = 7003;
+	const DEFAULT_PORT = 32123;
+	const REMEMBERED_PORT = 47311;
+	const RUNTIME = "/tmp/dev3-model-catalog-test/model-catalog-runtime";
+	let alive: Set<number>;
+	let table: string;
+	let files: string;
+	let holders: Map<number, number>;
+	let kill: MockInstance<typeof process.kill>;
+
+	beforeEach(() => {
+		alive = new Set([PROXY]);
+		table = `${PROXY} 1 /Applications/dev 3.app/bifrost-http\n`;
+		files = `p${PROXY}\nn${RUNTIME}/config.db\nn${RUNTIME}/logs.db\n`;
+		holders = new Map([[DEFAULT_PORT, PROXY]]);
+		h.freePorts = new Set([REMEMBERED_PORT]);
+		remember({ port: DEFAULT_PORT, sessionKey: "sk-bf-stable", pid: PROXY, ownerPid: OWNER });
+		h.findPortHolders.mockImplementation(async (ports: number[]) =>
+			ports.filter((port) => holders.has(port)).map((port) => ({ port, pid: holders.get(port), processName: "bifrost" })));
+		h.spawnMock.mockImplementation((cmd: string[]) => {
+			if (cmd[0] === "ps" || cmd[0] === "lsof") {
+				return { stdout: streamOf(cmd[0] === "ps" ? table : files), exited: Promise.resolve(0) };
+			}
+			return liveProcess();
+		});
+		kill = vi.spyOn(process, "kill").mockImplementation((pid, signal) => {
+			if (!alive.has(pid)) throw Object.assign(new Error("gone"), { code: "ESRCH" });
+			if (signal === "SIGTERM" || signal === "SIGKILL") {
+				alive.delete(pid);
+				for (const [port, holder] of holders) {
+					if (holder === pid) {
+						h.freePorts?.add(port);
+						holders.delete(port);
+					}
+				}
+			}
+			return true;
+		});
+	});
+
+	const signals = () => kill.mock.calls.filter(([, signal]) => signal !== 0);
+
+	it("terminates the recorded orphan before launching on the same default port and key", async () => {
+		const { ensureModelSidecar } = await freshModule();
+		expect(await ensureModelSidecar()).toEqual({ baseUrl: `http://127.0.0.1:${DEFAULT_PORT}`, sessionKey: "sk-bf-stable" });
+		expect(signals()).toEqual([[PROXY, "SIGTERM"]]);
+		expect(h.findPortHolders).not.toHaveBeenCalled();
+		const launchIndex = h.spawnMock.mock.calls.findIndex(([cmd]) => cmd[0] === "/opt/dev3/bifrost-http");
+		const signalIndex = kill.mock.calls.findIndex(([, signal]) => signal === "SIGTERM");
+		expect(kill.mock.invocationCallOrder[signalIndex]).toBeLessThan(h.spawnMock.mock.invocationCallOrder[launchIndex]);
+	});
+
+	it("never reclaims a proxy owned by another live instance", async () => {
+		alive.add(OWNER);
+		const { ensureModelSidecar } = await freshModule();
+		expect((await ensureModelSidecar()).baseUrl).not.toBe(`http://127.0.0.1:${DEFAULT_PORT}`);
+		expect(signals()).toEqual([]);
+	});
+
+	it("does not mistake denied owner inspection for a dead owner", async () => {
+		const original = kill.getMockImplementation()!;
+		kill.mockImplementation((pid, signal) => {
+			if (pid === OWNER) throw Object.assign(new Error("denied"), { code: "EPERM" });
+			return original(pid, signal);
+		});
+		const { ensureModelSidecar } = await freshModule();
+		await ensureModelSidecar();
+		expect(signals()).toEqual([]);
+	});
+
+	it("protects a live parent even when the recorded owner is dead", async () => {
+		alive.add(8001);
+		table = `${PROXY} 8001 /Applications/dev3.app/bifrost-http\n`;
+		const { ensureModelSidecar } = await freshModule();
+		await ensureModelSidecar();
+		expect(signals()).toEqual([]);
+	});
+
+	it("reclaims a legacy orphan with no ownership fields", async () => {
+		remember({ port: DEFAULT_PORT, sessionKey: "sk-bf-stable" });
+		const { ensureModelSidecar } = await freshModule();
+		expect((await ensureModelSidecar()).baseUrl).toBe(`http://127.0.0.1:${DEFAULT_PORT}`);
+		expect(signals()).toEqual([[PROXY, "SIGTERM"]]);
+		expect(h.spawnMock).toHaveBeenCalledWith(["ps", "-eo", "pid=,ppid=,comm="], expect.anything());
+		expect(h.spawnMock).toHaveBeenCalledWith(["lsof", "-a", "-p", String(PROXY), "-Fn"], expect.anything());
+	});
+
+	it("uses legacy identity when a writer left only a proxy pid", async () => {
+		remember({ port: DEFAULT_PORT, sessionKey: "sk-bf-stable", pid: PROXY });
+		const { ensureModelSidecar } = await freshModule();
+		await ensureModelSidecar();
+		expect(signals()).toEqual([[PROXY, "SIGTERM"]]);
+	});
+
+	it("never signals a recorded pid that has already exited", async () => {
+		alive.delete(PROXY);
+		const { ensureModelSidecar } = await freshModule();
+		await ensureModelSidecar();
+		expect(signals()).toEqual([]);
+	});
+
+	it("leaves a reused pid or unrelated listener alone", async () => {
+		table = `${PROXY} 1 /usr/bin/other-server\n`;
+		const { ensureModelSidecar } = await freshModule();
+		expect((await ensureModelSidecar()).baseUrl).not.toBe(`http://127.0.0.1:${DEFAULT_PORT}`);
+		expect(signals()).toEqual([]);
+	});
+
+	it.each([
+		`n${RUNTIME}/config.db\n`,
+		"n/tmp/another-runtime/config.db\nn/tmp/another-runtime/logs.db\n",
+	])("requires both database files from our exact runtime directory: %s", async (output) => {
+		files = output;
+		const { ensureModelSidecar } = await freshModule();
+		await ensureModelSidecar();
+		expect(signals()).toEqual([]);
+	});
+
+	it("compares open files against the real runtime path, including symlinks", async () => {
+		h.fs.realpathSync.mockReturnValue("/private/runtime");
+		files = "n/private/runtime/config.db\nn/private/runtime/logs.db\n";
+		const { ensureModelSidecar } = await freshModule();
+		await ensureModelSidecar();
+		expect(signals()).toEqual([[PROXY, "SIGTERM"]]);
+	});
+
+	it.each(["ps", "lsof"])("fails closed when %s is unavailable", async (tool) => {
+		const original = h.spawnMock.getMockImplementation()!;
+		h.spawnMock.mockImplementation((cmd, ...args) => {
+			if (cmd[0] === tool) throw new Error("ENOENT");
+			return original(cmd, ...args);
+		});
+		const { ensureModelSidecar } = await freshModule();
+		await ensureModelSidecar();
+		expect(signals()).toEqual([]);
+	});
+
+	it("fails closed on Windows instead of trusting a reused pid", async () => {
+		vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+		const { ensureModelSidecar } = await freshModule();
+		await ensureModelSidecar();
+		expect(signals()).toEqual([]);
+		expect(h.spawnMock.mock.calls.every(([cmd]) => cmd[0] === "/opt/dev3/bifrost-http")).toBe(true);
+	});
+
+	it("does not kill a recorded orphan on another port when the default is free", async () => {
+		h.freePorts?.add(DEFAULT_PORT);
+		holders = new Map([[REMEMBERED_PORT, PROXY]]);
+		remember({ port: REMEMBERED_PORT, sessionKey: "sk-bf-stable", pid: PROXY, ownerPid: OWNER });
+		const { ensureModelSidecar } = await freshModule();
+		expect((await ensureModelSidecar()).baseUrl).toBe(`http://127.0.0.1:${DEFAULT_PORT}`);
+		expect(signals()).toEqual([]);
+	});
+
+	it("reclaims only the default orphan and leaves the other orphan serving its sessions", async () => {
+		alive.add(OTHER_PROXY);
+		holders.set(REMEMBERED_PORT, OTHER_PROXY);
+		h.freePorts?.delete(REMEMBERED_PORT);
+		remember({ port: REMEMBERED_PORT, sessionKey: "sk-bf-stable", pid: OTHER_PROXY, ownerPid: OWNER });
+		const { ensureModelSidecar } = await freshModule();
+		expect((await ensureModelSidecar()).baseUrl).toBe(`http://127.0.0.1:${DEFAULT_PORT}`);
+		expect(signals()).toEqual([[PROXY, "SIGTERM"]]);
+		expect(alive.has(OTHER_PROXY)).toBe(true);
+	});
+
+	it("reclaims the remembered port when an unrelated process holds the default", async () => {
+		alive.add(OTHER_PROXY);
+		holders = new Map([[DEFAULT_PORT, OTHER_PROXY], [REMEMBERED_PORT, PROXY]]);
+		h.freePorts?.delete(REMEMBERED_PORT);
+		table += `${OTHER_PROXY} 1 /usr/bin/other-server\n`;
+		remember({ port: REMEMBERED_PORT, sessionKey: "sk-bf-stable", pid: PROXY, ownerPid: OWNER });
+		const { ensureModelSidecar } = await freshModule();
+		expect((await ensureModelSidecar()).baseUrl).toBe(`http://127.0.0.1:${REMEMBERED_PORT}`);
+		expect(signals()).toEqual([[PROXY, "SIGTERM"]]);
+	});
+});
+
 describe("autostart", () => {
 	it("brings the proxy up with the app, so the catalog needs no operating", async () => {
 		const { autostartModelSidecar, getModelSidecarStatus } = await freshModule();
@@ -399,6 +628,71 @@ describe("autostart", () => {
 });
 
 describe("stopping", () => {
+	it("signals the running proxy before the synchronous quit call returns", async () => {
+		const { ensureModelSidecar, killModelSidecarNow } = await freshModule();
+		await ensureModelSidecar();
+		const kill = vi.spyOn(process, "kill").mockReturnValue(true);
+		killModelSidecarNow();
+		expect(kill).toHaveBeenCalledExactlyOnceWith(5150, "SIGTERM");
+		expect(h.getDescendantPids).not.toHaveBeenCalled();
+	});
+
+	it("signals a spawned proxy before its health check resolves and never retries", async () => {
+		const { ensureModelSidecar, killModelSidecarNow } = await freshModule();
+		const kill = vi.spyOn(process, "kill").mockReturnValue(true);
+		let release!: (response: Response) => void;
+		let entered!: () => void;
+		const checking = new Promise<void>((resolve) => { entered = resolve; });
+		vi.stubGlobal("fetch", vi.fn(() => {
+			entered();
+			return new Promise<Response>((resolve) => { release = resolve; });
+		}));
+		const start = ensureModelSidecar();
+		const rejected = expect(start).rejects.toThrow(/shutting down/);
+		await checking;
+		killModelSidecarNow();
+		expect(kill).toHaveBeenCalledExactlyOnceWith(5150, "SIGTERM");
+		release({ ok: true } as Response);
+		await rejected;
+		expect(h.spawnMock).toHaveBeenCalledTimes(1);
+	});
+
+	it("does not spawn after quitting before the port probe resolves", async () => {
+		const { ensureModelSidecar, killModelSidecarNow } = await freshModule();
+		const start = ensureModelSidecar();
+		const rejected = expect(start).rejects.toThrow(/shutting down/);
+		killModelSidecarNow();
+		await rejected;
+		expect(h.spawnMock).not.toHaveBeenCalled();
+	});
+
+	it("does nothing synchronously when no proxy exists", async () => {
+		const { killModelSidecarNow } = await freshModule();
+		const kill = vi.spyOn(process, "kill").mockReturnValue(true);
+		expect(killModelSidecarNow).not.toThrow();
+		expect(kill).not.toHaveBeenCalled();
+	});
+
+	it("signals the proxy even while an RPC stop is waiting for its descendant scan", async () => {
+		const { ensureModelSidecar, stopModelSidecar, killModelSidecarNow } = await freshModule();
+		await ensureModelSidecar();
+		let release!: (pids: number[]) => void;
+		h.getDescendantPids.mockImplementation(() => new Promise((resolve) => { release = resolve; }));
+		const kill = vi.spyOn(process, "kill").mockReturnValue(true);
+		const stop = stopModelSidecar();
+		killModelSidecarNow();
+		expect(kill).toHaveBeenCalledExactlyOnceWith(5150, "SIGTERM");
+		release([]);
+		await stop;
+	});
+
+	it.each(["ESRCH", "EPERM"])("never throws when signalling fails with %s", async (code) => {
+		const { ensureModelSidecar, killModelSidecarNow } = await freshModule();
+		await ensureModelSidecar();
+		vi.spyOn(process, "kill").mockImplementation(() => { throw Object.assign(new Error(code), { code }); });
+		expect(killModelSidecarNow).not.toThrow();
+	});
+
 	it("terminates the process tree, not only the parent", async () => {
 		h.getDescendantPids.mockResolvedValue([6001]);
 		const killed: number[] = [];

--- a/src/bun/index.ts
+++ b/src/bun/index.ts
@@ -43,6 +43,7 @@ import { startSocketServer, stopSocketServer } from "./cli-socket-server";
 import { startRemoteAccessServerGuarded, setRemoteAccessStatusHook } from "./remote-access-server";
 import { writeSystemClipboard } from "./system-clipboard";
 import { stopTunnel } from "./cloudflare-tunnel";
+import { killModelSidecarNow } from "./model-sidecar";
 import { installAgentSkills } from "./agent-skills";
 import { managedCliWriteAllowed } from "./managed-cli-guard";
 import { ensureCodexConfigFile } from "./codex-config";
@@ -803,7 +804,7 @@ function runGlobalQuitCleanup(): void {
 	try { stopTunnel(); } catch (err) { log.warn("stopTunnel failed", { error: String(err) }); }
 	// The model-catalog proxy dies with the app — an orphan would keep holding a
 	// loopback port and the user's provider keys in memory.
-	import("./model-sidecar").then(({ stopModelSidecar }) => stopModelSidecar()).catch(() => { /* shutdown — best-effort */ });
+	try { killModelSidecarNow(); } catch (err) { log.warn("killModelSidecarNow failed", { error: String(err) }); }
 }
 
 // Terminal/OS signals (Ctrl+C in `bun run dev`, kill, shutdown) bypass the

--- a/src/bun/model-sidecar.ts
+++ b/src/bun/model-sidecar.ts
@@ -7,7 +7,7 @@
 
 import { createServer } from "node:net";
 import { chmodSync, existsSync, mkdirSync, readFileSync, realpathSync, writeFileSync } from "node:fs";
-import { dirname, join, resolve } from "node:path";
+import { basename, dirname, join, resolve } from "node:path";
 import {
 	ENCRYPTION_KEY_ENV,
 	SESSION_KEY_ENV,
@@ -26,7 +26,8 @@ import type { ModelSidecarStatus, ModelCatalogPreflight } from "../shared/types"
 import { createLogger } from "./logger";
 import { loadModelCatalog, loadOrCreateEncryptionKey, loadProviderKeys } from "./model-catalog-store";
 import { DEV3_HOME } from "./paths";
-import { getDescendantPids } from "./port-scanner";
+import { findPortHolders, getDescendantPids } from "./port-scanner";
+import { terminatePidsVerified } from "./process-reaper";
 import { spawn } from "./spawn";
 
 const log = createLogger("model-sidecar");
@@ -71,6 +72,9 @@ interface RunningSidecar {
 
 let running: RunningSidecar | null = null;
 let starting: Promise<RunningSidecar> | null = null;
+let startingPid: number | undefined;
+let stoppingPid: number | undefined;
+let shuttingDown = false;
 let lastError: string | undefined;
 
 /** Where the bundled binary may sit, mirroring the bundled-tmux layout: inside
@@ -135,6 +139,12 @@ export async function isPortFree(port: number): Promise<boolean> {
 export interface SidecarEndpoint {
 	port: number;
 	sessionKey: string;
+	pid?: number;
+	ownerPid?: number;
+}
+
+function validPid(pid: unknown): pid is number {
+	return typeof pid === "number" && Number.isSafeInteger(pid) && pid > 1;
 }
 
 /** The remembered endpoint, or null when there is none / it is unreadable. */
@@ -145,10 +155,94 @@ export function loadSidecarEndpoint(path = ENDPOINT_PATH): SidecarEndpoint | nul
 		const sessionKey = parsed.sessionKey;
 		if (typeof port !== "number" || !Number.isInteger(port) || port < 1 || port > 65535) return null;
 		if (typeof sessionKey !== "string" || !sessionKey.startsWith("sk-bf-")) return null;
-		return { port, sessionKey };
+		return {
+			port, sessionKey,
+			...(validPid(parsed.pid) ? { pid: parsed.pid } : {}),
+			...(validPid(parsed.ownerPid) ? { ownerPid: parsed.ownerPid } : {}),
+		};
 	} catch {
 		return null;
 	}
+}
+
+// A permission error is not evidence that an owner died. Only ESRCH permits reclaim.
+function pidMayBeAlive(pid: number): boolean {
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch (err) {
+		return (err as NodeJS.ErrnoException).code !== "ESRCH";
+	}
+}
+
+async function inspectText(cmd: string[]): Promise<string> {
+	const proc = spawn(cmd, { stdout: "pipe", stderr: "ignore" });
+	const [text, code] = await Promise.all([new Response(proc.stdout).text(), proc.exited]);
+	if (code !== 0) throw new Error("Process inspection failed");
+	return text;
+}
+
+async function isLeakedSidecar(pid: number, remembered: SidecarEndpoint | null): Promise<boolean> {
+	if (!validPid(pid) || !pidMayBeAlive(pid)) return false;
+	if (remembered?.pid === pid && remembered.ownerPid && pidMayBeAlive(remembered.ownerPid)) return false;
+	try {
+		if (process.platform === "win32") throw new Error("Proxy identity inspection is unavailable on Windows");
+		// The shared process tree is cached and reads args. Reaping requires a fresh
+		// comm snapshot: argv inspection is restricted in the packaged app.
+		const table = await inspectText(["ps", "-eo", "pid=,ppid=,comm="]);
+		const row = table.split("\n")
+			.map((line) => line.trim().match(/^(\d+)\s+(\d+)\s+(.+)$/))
+			.find((match) => match && Number(match[1]) === pid);
+		if (!row) throw new Error("Proxy process identity could not be read");
+		if (basename(row[3]) !== "bifrost-http") return false;
+		const parentPid = Number(row[2]);
+		// Protect every live non-init parent, including unfamiliar dev builds and
+		// subreapers. An unreadable parent is not proof of an orphan.
+		if (parentPid !== 1 && (!validPid(parentPid) || pidMayBeAlive(parentPid))) return false;
+		const files = await inspectText(["lsof", "-a", "-p", String(pid), "-Fn"]);
+		const names = new Set(files.split("\n").filter((line) => line.startsWith("n")).map((line) => line.slice(1)));
+		const runtime = realpathSync(RUNTIME_DIR);
+		return names.has(join(runtime, "config.db")) && names.has(join(runtime, "logs.db"));
+	} catch (err) {
+		log.warn("Could not confirm model proxy ownership; leaving the process alone", { pid, error: String(err) });
+		return false;
+	}
+}
+
+/** Reclaim only the first usable address. Other orphans may still serve agents. */
+async function reclaimLeakedSidecar(remembered: SidecarEndpoint | null): Promise<number | undefined> {
+	const ports = [...new Set([DEFAULT_SIDECAR_PORT, ...(remembered ? [remembered.port] : [])])];
+	for (const port of ports) {
+		if (shuttingDown || await isPortFree(port)) return undefined;
+		try {
+			const recorded = remembered?.port === port ? remembered : null;
+			let pid = recorded?.ownerPid ? recorded.pid : undefined;
+			if (!pid || !await isLeakedSidecar(pid, recorded)) {
+				if (process.platform === "win32") {
+					log.warn("Could not confirm model proxy ownership on Windows; leaving the occupied port alone", { port });
+					continue;
+				}
+				const holders = await findPortHolders([port]);
+				const legacyPid = holders[0]?.pid;
+				if (!legacyPid || legacyPid === pid || !await isLeakedSidecar(legacyPid, null)) continue;
+				pid = legacyPid;
+			}
+			// Recheck owner liveness after asynchronous inspection, before signalling.
+			if (shuttingDown || (recorded?.pid === pid && recorded.ownerPid && pidMayBeAlive(recorded.ownerPid))) return undefined;
+			const survivors = await terminatePidsVerified([pid]);
+			if (survivors.length > 0) {
+				log.warn("Leaked model proxy did not exit", { pid, port });
+				return undefined;
+			}
+			await waitForPortRelease(port);
+			log.info("Reclaimed leaked model proxy endpoint", { pid, port });
+			return port;
+		} catch (err) {
+			log.warn("Could not reclaim model proxy endpoint", { port, error: String(err) });
+			return undefined;
+		}
+	}
+	return undefined;
 }
 
 function saveSidecarEndpoint(endpoint: SidecarEndpoint): void {
@@ -248,11 +342,14 @@ async function launchOnce(binary: string, env: Record<string, string>, sessionKe
 		[binary, "-host", "127.0.0.1", "-port", String(port), "-app-dir", RUNTIME_DIR, "-log-level", "warn", "-log-style", "json"],
 		{ env, stdout: "pipe", stderr: "pipe", stdin: "ignore" },
 	);
+	startingPid = proc.pid;
 
 	let exited = false;
 	let self: RunningSidecar | undefined;
 	void proc.exited.then((code) => {
 		exited = true;
+		if (startingPid === proc.pid) startingPid = undefined;
+		if (stoppingPid === proc.pid) stoppingPid = undefined;
 		// A proxy that dies on its own must stop being the one we hand out: without
 		// this every later launch is routed at a dead port and the panel keeps
 		// saying "running", with the Start button hidden behind a Stop.
@@ -307,6 +404,7 @@ async function pumpStream(stream: unknown, push: (chunk: string) => void): Promi
 /** Start the sidecar if it is not up and return its runtime. Concurrent callers
  *  share one start, so two launches cannot race two processes onto two ports. */
 export async function ensureModelSidecar(): Promise<{ baseUrl: string; sessionKey: string }> {
+	if (shuttingDown) throw new Error("The model proxy is shutting down.");
 	if (running) return { baseUrl: running.baseUrl, sessionKey: running.sessionKey };
 	if (!starting) starting = startSidecar().finally(() => (starting = null));
 	const instance = await starting;
@@ -341,6 +439,7 @@ async function startSidecar(): Promise<RunningSidecar> {
 	// Reuse the last endpoint: an agent's base URL and token are baked into its
 	// launch env, so a fresh port or key would strand every running session.
 	const remembered = loadSidecarEndpoint();
+	const reclaimedPort = await reclaimLeakedSidecar(remembered);
 	const sessionKey = remembered?.sessionKey ?? `sk-bf-${randomSecret(24)}`;
 	const env = buildSidecarEnv(catalog, loadProviderKeys(), {
 		sessionKey,
@@ -350,8 +449,11 @@ async function startSidecar(): Promise<RunningSidecar> {
 	let failure: unknown;
 	for (let attempt = 1; attempt <= START_ATTEMPTS; attempt += 1) {
 		try {
-			const port = await choosePort(attempt, remembered);
+			if (shuttingDown) throw new Error("The model proxy is shutting down.");
+			const port = attempt === 1 && reclaimedPort !== undefined ? reclaimedPort : await choosePort(attempt, remembered);
+			if (shuttingDown) throw new Error("The model proxy is shutting down.");
 			const instance = await launchOnce(binary, env, sessionKey, port);
+			if (shuttingDown) throw new Error("The model proxy is shutting down.");
 			// It can die between answering /health and getting here (a bad provider
 			// config it only notices on the first request, a stolen port, an OOM).
 			// Its own exit handler cannot clean that up — it never saw this instance
@@ -359,17 +461,32 @@ async function startSidecar(): Promise<RunningSidecar> {
 			// forever with every launch routed at a dead port.
 			if (instance.hasExited()) throw new Error(`The model proxy exited right after starting.\n${instance.output()}`.trim());
 			running = instance;
-			saveSidecarEndpoint({ port: instance.port, sessionKey });
+			if (startingPid === instance.pid) startingPid = undefined;
+			saveSidecarEndpoint({ port: instance.port, sessionKey, pid: instance.pid, ownerPid: process.pid });
 			lastError = undefined;
 			log.info("Model proxy started", { pid: instance.pid, port: instance.port, attempt });
 			return instance;
 		} catch (err) {
 			failure = err;
+			if (shuttingDown) break;
 			log.warn("Model proxy start attempt failed", { attempt, error: String(err) });
 		}
 	}
 	lastError = String(failure instanceof Error ? failure.message : failure);
 	throw new Error(lastError);
+}
+
+/** Quit cannot await imports, health checks or descendant scans. */
+export function killModelSidecarNow(): void {
+	shuttingDown = true;
+	for (const pid of new Set([running?.pid, startingPid, stoppingPid])) {
+		if (!validPid(pid)) continue;
+		try {
+			process.kill(pid, "SIGTERM");
+		} catch {
+			/* already gone or not permitted; shutdown must not throw */
+		}
+	}
 }
 
 /** Bring the proxy up at app start, so the catalog is a place you configure
@@ -409,6 +526,7 @@ export async function stopModelSidecar(): Promise<void> {
 	// the start path calls stop, so waiting here cannot deadlock.
 	if (starting) await starting.catch(() => undefined);
 	const instance = running;
+	stoppingPid = instance?.pid ?? stoppingPid;
 	running = null;
 	// Stopping on purpose dismisses whatever went wrong before — otherwise a proxy
 	// that died on its own keeps showing its exit message after the user turned it


### PR DESCRIPTION
## Summary

- Replace deferred quit cleanup with a statically imported synchronous SIGTERM path, covering running, starting, and asynchronously stopping proxies. Prevent delayed startup or retries after quit.
- Add optional proxy/owner PIDs to the existing endpoint file. Reclaim only the default or remembered address the replacement will bind, after fresh executable/open-database identity and owner-liveness checks.
- Keep the port-release wait for RPC stop/restart. Preserve other live instances, unrelated listeners, and orphaned routes on unselected ports.
- Add regression coverage, a user-visible changelog, and a decision record superseding the earlier squatter assumption.

## Verification

- `bun run lint`: passed.
- `bun run test:full`: passed on the final rebased commit: 14,963 passed, 3 skipped across 890 files.
- Packaged macOS app with the real pinned Bifrost binary and hardened Bun runtime, using an isolated QA home:
  - Confirmed normal quit exits both app and proxy.
  - Force-killed only the main process, confirmed the proxy became orphaned, then confirmed startup reclaimed it and reused its port.
  - Five consecutive quit/relaunch cycles kept the same port and session key; authenticated requests through a local test provider returned HTTP 200 after each.
  - Removed the optional PID fields to exercise legacy listener/open-file discovery; the packaged app reclaimed the orphan.
  - Installed app continued owning 32123 throughout; the QA app used remembered port 59269 and never killed the installed proxy.
- QA app and proxy stopped after verification.

## Limits and Follow-up

- A real routed Codex conversation across restart and legacy takeover specifically on 32123 remain manual acceptance checks. QA used authenticated chat-completion requests, not a real provider account or agent turn.
- Windows fails closed when identity cannot be verified: optional PID metadata alone cannot safely authorize a kill. No Windows process-enumeration scope was added.
- Existing orphans on other ports remain untouched because they may still serve running sessions.
- The separate deferred task-tunnel cleanup risk was filed as dev3 task #22. The unrelated provider `/v1` URL issue was not changed.

---

🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=688e7e58-d232-49ca-b9d1-7007cab4a5c3) · `dev3://task/688e7e58-d232-49ca-b9d1-7007cab4a5c3` _(dev3 added this footer — turn it off in Settings → Tasks.)_